### PR TITLE
Environment variable to allow encoded slashes

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -99,4 +99,8 @@ CacheRoot /tmp
  WSGIScriptAlias /lifetime_exceptions    /usr/lib/python2.7/site-packages/rucio/web/rest/lifetime_exception.py
 {% endif %}
 
+{% if RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
+ AllowEncodedSlashes on
+{% endif %}
+
 </VirtualHost>


### PR DESCRIPTION
CMS needs this setting to be settable.

Can you try to let me know when a container with it included is in docker hub? Right now I've had to switch to my own container.