### PR TITLE
Enforce apache to follow chain of certificates

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -52,6 +52,9 @@ CacheRoot /tmp
 {% else %}
  SSLCACertificateFile /etc/grid-security/ca.pem
 {% endif %}
+ SSLCACertificatePath /etc/grid-security/certificates
+ SSLCARevocationPath /etc/grid-security/certificates
+ SSLCARevocationCheck chain
  SSLVerifyClient optional_no_ca
  SSLVerifyDepth 10
  SSLOptions +StdEnvVars

--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -49,10 +49,10 @@ CacheRoot /tmp
 {% if RUCIO_CA_PATH is defined %}
  SSLCACertificatePath {{ RUCIO_CA_PATH }}
  SSLCARevocationPath {{ RUCIO_CA_PATH }}
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
 {% else %}
  SSLCACertificateFile /etc/grid-security/ca.pem
 {% endif %}
- SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
  SSLVerifyClient optional_no_ca
  SSLVerifyDepth 10
  SSLOptions +StdEnvVars

--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -52,9 +52,7 @@ CacheRoot /tmp
 {% else %}
  SSLCACertificateFile /etc/grid-security/ca.pem
 {% endif %}
- SSLCACertificatePath /etc/grid-security/certificates
- SSLCARevocationPath /etc/grid-security/certificates
- SSLCARevocationCheck chain
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
  SSLVerifyClient optional_no_ca
  SSLVerifyDepth 10
  SSLOptions +StdEnvVars


### PR DESCRIPTION
I found that certain clients (Go language) pass client certificate as a whole. This patch enforces apache server to follow the certificate chain. In order to validate client certificates though the proper SSLCACertificatePath and SSLCARevocationPath is required (I put standard /etc/grid-security/certificates).

Please note, that it is not required for curl or Python clients whose SSL library creates internally chain of certificates and pass them to apache server individually.