### PR TITLE
Remove VOLUME from Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -38,7 +38,6 @@ RUN rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/userdir.conf /etc/httpd/
 
 VOLUME /var/log/httpd
 VOLUME /opt/rucio/etc
-VOLUME /etc/grid-security
 
 EXPOSE 443
 


### PR DESCRIPTION
Need to get rid of the grid security volume here so we can install our own certs in the container. Otherwise we cannot get the UI to work with non-CERN certs.