### PR TITLE
Reduce image bloat by about half

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -15,19 +15,25 @@ ARG TAG
 WORKDIR /tmp
 ADD oic.rpm /tmp
 
-RUN yum install -y epel-release.noarch
-RUN yum upgrade -y
-RUN yum install -y python-pip libaio gcc python-devel.x86_64 openssl-devel.x86_64 MySQL-python
+RUN yum install -y epel-release.noarch && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum install -y python-pip libaio gcc python-devel.x86_64 openssl-devel.x86_64 MySQL-python && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir --upgrade setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
-RUN pip install --pre rucio[oracle,mysql,postgresql]==$TAG
-RUN pip install j2cli psycopg2-binary
-RUN pip install cx_oracle==6.3.1 PyMySQL
+RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
+RUN pip install --no-cache-dir j2cli psycopg2-binary
+RUN pip install --no-cache-dir cx_oracle==6.3.1 PyMySQL
 
 # Install dependecies
 RUN yum install -y \
@@ -40,7 +46,9 @@ RUN yum install -y \
     gfal2-python \
     xrootd-client \
     sendmail \
-    sendmail-cf
+    sendmail-cf && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 ADD rucio.cfg.j2 /tmp/
 ADD start-daemon.sh /

--- a/daemons/Dockerfile_py3
+++ b/daemons/Dockerfile_py3
@@ -15,19 +15,25 @@ ARG TAG
 WORKDIR /tmp
 ADD oic.rpm /tmp
 
-RUN yum install -y epel-release.noarch
-RUN yum upgrade -y
-RUN yum install -y python3 libaio gcc python36-devel.x86_64 openssl-devel.x86_64 mod_ssl python3-m2crypto libnsl.x86_64
+RUN yum install -y epel-release.noarch && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum install -y python3 libaio gcc python36-devel.x86_64 openssl-devel.x86_64 mod_ssl python3-m2crypto libnsl.x86_64 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install --no-cache-dir  --upgrade pip
+RUN python3 -m pip install --no-cache-dir  --upgrade setuptools
 RUN rm -rf /usr/lib/python3.6/site-packages/ipaddress*
-RUN python3 -m pip install --pre rucio[oracle,mysql,postgresql]==$TAG
-RUN python3 -m pip install j2cli psycopg2-binary
-RUN python3 -m pip install cx_oracle==6.3.1 PyMySQL
+RUN python3 -m pip install --no-cache-dir  --pre rucio[oracle,mysql,postgresql]==$TAG
+RUN python3 -m pip install --no-cache-dir  j2cli psycopg2-binary
+RUN python3 -m pip install --no-cache-dir  cx_oracle==6.3.1 PyMySQL
 
 # Install dependecies
 RUN yum install -y \
@@ -39,7 +45,9 @@ RUN yum install -y \
     gfal2-plugin-xrootd \
     xrootd-client \
     sendmail \
-    sendmail-cf
+    sendmail-cf && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 ADD rucio.cfg.j2 /tmp/
 ADD start-daemon_py3.sh /start-daemon.sh

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -28,11 +28,11 @@ RUN rpm -i /tmp/oic.rpm; \
 
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.0/jobber-1.4.0-1.el7.x86_64.rpm
 
-RUN pip install --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
-RUN pip install --pre rucio[oracle,mysql,postgresql]
-RUN pip install j2cli psycopg2-binary
-RUN pip install cx_oracle==6.3.1 PyMySQL
+RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]
+RUN pip install --no-cache-dir j2cli psycopg2-binary
+RUN pip install --no-cache-dir cx_oracle==6.3.1 PyMySQL
 
 WORKDIR /
 RUN git clone https://github.com/rucio/probes.git

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -15,19 +15,25 @@ ARG TAG
 WORKDIR /tmp
 ADD oic.rpm /tmp
 
-RUN yum install -y epel-release.noarch
-RUN yum upgrade -y
-RUN yum install -y httpd mod_wsgi python-pip libaio gcc python-devel.x86_64 mod_ssl openssl-devel.x86_64 MySQL-python
+RUN yum install -y epel-release.noarch && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum install -y httpd mod_wsgi python-pip libaio gcc python-devel.x86_64 mod_ssl openssl-devel.x86_64 MySQL-python && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
+RUN pip install --no-cache-dir  --upgrade pip
+RUN pip install  --no-cache-dir --upgrade setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
-RUN pip install --pre rucio[oracle,mysql,postgresql]==$TAG
-RUN pip install j2cli psycopg2-binary
-RUN pip install cx_oracle==6.3.1 PyMySQL
+RUN pip install --no-cache-dir  --pre rucio[oracle,mysql,postgresql]==$TAG
+RUN pip install --no-cache-dir  j2cli psycopg2-binary
+RUN pip install --no-cache-dir  cx_oracle==6.3.1 PyMySQL
 
 ADD rucio.cfg.j2 /tmp/
 ADD rucio.conf.j2 /tmp/

--- a/server/Dockerfile_py3
+++ b/server/Dockerfile_py3
@@ -15,19 +15,25 @@ ARG TAG
 WORKDIR /tmp
 ADD oic.rpm /tmp
 
-RUN yum install -y epel-release.noarch
-RUN yum upgrade -y
-RUN yum install -y httpd python3 python3-mod_wsgi libaio gcc python36-devel.x86_64 mod_ssl openssl-devel.x86_64 python3-m2crypto libnsl.x86_64
+RUN yum install -y epel-release.noarch && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum install -y httpd python3 python3-mod_wsgi libaio gcc python36-devel.x86_64 mod_ssl openssl-devel.x86_64 python3-m2crypto libnsl.x86_64 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install --upgrade setuptools
+RUN python3 -m pip install --no-cache-dir  --upgrade pip
+RUN python3 -m pip install --no-cache-dir  --upgrade setuptools
 RUN rm -rf /usr/lib/python3.6/site-packages/ipaddress*
-RUN python3 -m pip install --pre rucio[oracle,mysql,postgresql]==$TAG
-RUN python3 -m pip install j2cli psycopg2-binary
-RUN python3 -m pip install cx_oracle==6.3.1 PyMySQL
+RUN python3 -m pip install --no-cache-dir  --pre rucio[oracle,mysql,postgresql]==$TAG
+RUN python3 -m pip install --no-cache-dir  j2cli psycopg2-binary
+RUN python3 -m pip install --no-cache-dir  cx_oracle==6.3.1 PyMySQL
 
 ADD rucio.cfg.j2 /tmp/
 ADD rucio.conf.j2.py3 /tmp/rucio.conf.j2

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -14,21 +14,27 @@ ARG TAG
 WORKDIR /tmp
 ADD oic.rpm /tmp
 
-RUN yum install -y epel-release.noarch
-RUN yum upgrade -y
-RUN yum install -y httpd mod_wsgi python-pip libaio gcc python-devel.x86_64 mod_ssl  openssl-devel.x86_64
+RUN yum install -y epel-release.noarch && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+RUN yum install -y httpd mod_wsgi python-pip libaio gcc python-devel.x86_64 mod_ssl  openssl-devel.x86_64 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN pip install --upgrade pip
-RUN pip install --upgrade setuptools
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir --upgrade setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
-RUN pip install --pre rucio[oracle,mysql,postgresql]==$TAG
-RUN pip install --pre rucio_webui==$TAG
-RUN pip install j2cli psycopg2-binary
+RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
+RUN pip install --no-cache-dir --pre rucio_webui==$TAG
+RUN pip install --no-cache-dir j2cli psycopg2-binary
 # only necessary temporarily until setup.py for webui is fixed
-RUN pip install cx_oracle==6.3.1 PyMySQL
+RUN pip install --no-cache-dir cx_oracle==6.3.1 PyMySQL
 
 ADD rucio.cfg.j2 /tmp/
 ADD rucio.conf.j2 /tmp/


### PR DESCRIPTION
By removing or never generation caches of rpm and pip installs, we can drastically reduce the size of the images. 

A test with daemons shows the added amount goes from 400 MB down to 210 MB for the install: https://hub.docker.com/repository/registry-1.docker.io/ericvaandering/test-daemons/tags?page=1

1.0.0 is the deftaul
1.0.1 removes RPM caches
1.0.2 eliminates pip caching
