### PR TITLE
Modify FTS3 Delegation CronJob to not require access to the root directory

### DIFF
--- a/fts-cron/Dockerfile
+++ b/fts-cron/Dockerfile
@@ -29,12 +29,13 @@ RUN pip install j2cli
 
 RUN mkdir -p /opt/rucio/certs/
 RUN mkdir -p /opt/rucio/kubeconfig/
+RUN mkdir -p -m 775 /opt/rucio/fts-delegate/
 
-ADD docker-entrypoint.sh /
-ADD renew_fts_proxy.sh.j2 /
-ADD renew_fts_proxy_atlas.sh.j2 /
-ADD renew_fts_proxy_dteam.sh.j2 /
-ADD renew_fts_proxy_tutorial.sh.j2 /
+ADD docker-entrypoint.sh /opt/rucio/fts-delegate/
+ADD renew_fts_proxy.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_atlas.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_dteam.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_tutorial.sh.j2 /opt/rucio/fts-delegate/
 ADD rucio_ca.pem /etc/grid-security/certificates/
 
 ADD dteam* /etc/vomses/

--- a/fts-cron/docker-entrypoint.sh
+++ b/fts-cron/docker-entrypoint.sh
@@ -2,21 +2,21 @@
 
 if [[ $RUCIO_VO == 'atlas' ]]
 then
-    j2 /renew_fts_proxy_atlas.sh.j2 > /renew_fts_proxy.sh
+    j2 /opt/rucio/fts-delegate/renew_fts_proxy_atlas.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
 elif [[ $RUCIO_VO == 'dteam' ]]
 then
-    j2 /renew_fts_proxy_dteam.sh.j2 > /renew_fts_proxy.sh
+    j2 /opt/rucio/fts-delegate/renew_fts_proxy_dteam.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
 elif [[ $RUCIO_VO == 'tutorial' ]]
 then
-    j2 /renew_fts_proxy_tutorial.sh.j2 > /renew_fts_proxy.sh
+    j2 /opt/rucio/fts-delegate/renew_fts_proxy_tutorial.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
 else
-    j2 /renew_fts_proxy.sh.j2 > /renew_fts_proxy.sh
+    j2 /opt/rucio/fts-delegate/renew_fts_proxy.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
 fi
 
-chmod +x /renew_fts_proxy.sh
+chmod +x /opt/rucio/fts-delegate/renew_fts_proxy.sh
 
 echo "=================== /renew_fts_proxy.sh ========================"
-cat /renew_fts_proxy.sh
+cat /opt/rucio/fts-delegate/renew_fts_proxy.sh
 echo ""
 
-/renew_fts_proxy.sh
+/opt/rucio/fts-delegate/renew_fts_proxy.sh


### PR DESCRIPTION
Openshift seems to have more restrictive settings regarding setting root directory permissions compared to raw Kubernetes. Instead, do all the work of the fts-cron container in a "non-root" directory to work around this issue consistently for all cluster types.