### PR TITLE
Fix the ordering of pip and setuptools to allow container to build

### DIFF
--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -28,7 +28,8 @@ RUN rpm -i /tmp/oic.rpm; \
 
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.0/jobber-1.4.0-1.el7.x86_64.rpm
 
-RUN pip install --no-cache-dir --upgrade pip setuptools
+RUN pip install --no-cache-dir --upgrade pip 
+RUN pip install --no-cache-dir --upgrade setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
 RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]
 RUN pip install --no-cache-dir j2cli psycopg2-binary


### PR DESCRIPTION
The probes are not building because of this error fixed elsewhere. Can you merge this and trigger a build of the probes container? It still dates from an old install of Rucio