### PR TITLE
Add environment variable to specify httpd logging directory.

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -73,8 +73,13 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_ENABLE_LOGFILE|default('False') == 'True' %}
+{% if RUCIO_HTTPD_LOG_DIR is defined %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR}}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR}}/error_log
+{% else %}
  CustomLog logs/access_log combinedrucio
  ErrorLog logs/error_log
+{% endif %}
 {% else %}
  CustomLog /dev/stdout combinedrucio
  ErrorLog /dev/stderr


### PR DESCRIPTION
In case you need to move where the Apache logs are saved, I added an environment variable to do so.

In our case I want to write the logs to a shared persistent volume with the Rucio daemons, which can be seen by a pod running a Filebeat container.