### PR TITLE
Add HTTPD logging directory environment variable to web UI

### DIFF
--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -62,8 +62,13 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_ENABLE_LOGFILE|default('False') == 'True' %}
+{% if RUCIO_HTTPD_LOG_DIR is defined %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR}}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR}}/error_log
+{% else %}
  CustomLog logs/access_log combinedrucio
  ErrorLog logs/error_log
+{% endif %}
 {% else %}
  CustomLog /dev/stdout combinedrucio
  ErrorLog /dev/stderr


### PR DESCRIPTION
Need to also specify the logging directory for the Web UI for export to Fermilab persistent storage.