### PR TITLE
kill any running httpd processes before starting

### DIFF
--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -31,4 +31,6 @@ echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""
 
+pkill httpd || :
+sleep 2
 httpd -D FOREGROUND


### PR DESCRIPTION
This is necessary when running the server with `docker run --restart always` so that the server can start properly after a docker restart.