### PR TITLE
Add policy package option to Rucio configuration file templates.

### DIFF
--- a/clients/rucio.cfg.j2
+++ b/clients/rucio.cfg.j2
@@ -26,3 +26,4 @@ schema = {{ RUCIO_CFG_POLICY_SCHEMA | default('generic') }}
 lfn2pfn_algorithm_default = {{ RUCIO_CFG_POLICY_LFN2PFN_ALGORITHM_DEFAULT | default('hash') }}
 support = {{ RUCIO_CFG_POLICY_SUPPORT | default('https://github.com/rucio/rucio/issues/') }}
 support_rucio = {{ RUCIO_CFG_POLICY_SUPPORT_RUCIO | default('https://github.com/rucio/rucio/issues/') }}
+{% if RUCIO_CFG_POLICY_PACKAGE is defined %}package = {{ RUCIO_CFG_POLICY_PACKAGE }}{% endif %}

--- a/daemons/rucio.cfg.j2
+++ b/daemons/rucio.cfg.j2
@@ -32,6 +32,7 @@ permission = {{ RUCIO_CFG_POLICY_PERMISSION | default('generic') }}
 schema = {{ RUCIO_CFG_POLICY_SCHEMA | default('generic') }}
 lfn2pfn_algorithm_default = {{ RUCIO_CFG_POLICY_LFN2PFN_ALGORITHM_DEFAULT | default('hash') }}
 {% if RUCIO_CFG_POLICY_LFN2PFN_MODULE is defined %}lfn2pfn_module = {{ RUCIO_CFG_POLICY_LFN2PFN_MODULE }}{% endif %}
+{% if RUCIO_CFG_POLICY_PACKAGE is defined %}package = {{ RUCIO_CFG_POLICY_PACKAGE }}{% endif %}
 
 support = {{ RUCIO_CFG_POLICY_SUPPORT | default('https://github.com/rucio/rucio/issues/') }}
 support_rucio = {{ RUCIO_CFG_POLICY_SUPPORT_RUCIO | default('https://github.com/rucio/rucio/issues/') }}

--- a/probes/rucio.cfg.j2
+++ b/probes/rucio.cfg.j2
@@ -31,6 +31,7 @@ permission = {{ RUCIO_CFG_POLICY_PERMISSION | default('generic') }}
 schema = {{ RUCIO_CFG_POLICY_SCHEMA | default('generic') }}
 lfn2pfn_algorithm_default = {{ RUCIO_CFG_POLICY_LFN2PFN_ALGORITHM_DEFAULT | default('hash') }}
 {% if RUCIO_CFG_POLICY_LFN2PFN_MODULE is defined %}lfn2pfn_module = {{ RUCIO_CFG_POLICY_LFN2PFN_MODULE }}{% endif %}
+{% if RUCIO_CFG_POLICY_PACKAGE is defined %}package = {{ RUCIO_CFG_POLICY_PACKAGE }}{% endif %}
 
 support = {{ RUCIO_CFG_POLICY_SUPPORT | default('https://github.com/rucio/rucio/issues/') }}
 support_rucio = {{ RUCIO_CFG_POLICY_SUPPORT_RUCIO | default('https://github.com/rucio/rucio/issues/') }}

--- a/server/rucio.cfg.j2
+++ b/server/rucio.cfg.j2
@@ -46,6 +46,7 @@ lfn2pfn_algorithm_default = {{ RUCIO_CFG_POLICY_LFN2PFN_ALGORITHM_DEFAULT | defa
 support = {{ RUCIO_CFG_POLICY_SUPPORT | default('https://github.com/rucio/rucio/issues/') }}
 support_rucio = {{ RUCIO_CFG_POLICY_SUPPORT_RUCIO | default('https://github.com/rucio/rucio/issues/') }}
 {% if RUCIO_CFG_POLICY_LFN2PFN_MODULE is defined %}lfn2pfn_module = {{ RUCIO_CFG_POLICY_LFN2PFN_MODULE }}{% endif %}
+{% if RUCIO_CFG_POLICY_PACKAGE is defined %}package = {{ RUCIO_CFG_POLICY_PACKAGE }}{% endif %}
 
 [credentials]
 gcs = {{ RUCIO_CFG_CREDENTIALS_GCS | default('/opt/rucio/etc/google-cloud-storage-test.json') }}

--- a/ui/rucio.cfg.j2
+++ b/ui/rucio.cfg.j2
@@ -46,6 +46,7 @@ lfn2pfn_algorithm_default = {{ RUCIO_CFG_POLICY_LFN2PFN_ALGORITHM_DEFAULT | defa
 support = {{ RUCIO_CFG_POLICY_SUPPORT | default('https://github.com/rucio/rucio/issues/') }}
 support_rucio = {{ RUCIO_CFG_POLICY_SUPPORT_RUCIO | default('https://github.com/rucio/rucio/issues/') }}
 {% if RUCIO_CFG_POLICY_LFN2PFN_MODULE is defined %}lfn2pfn_module = {{ RUCIO_CFG_POLICY_LFN2PFN_MODULE }}{% endif %}
+{% if RUCIO_CFG_POLICY_PACKAGE is defined %}package = {{ RUCIO_CFG_POLICY_PACKAGE }}{% endif %}
 
 [webui]
 usercert = {{ RUCIO_CFG_WEBUI_USERCERT | default('/opt/rucio/etc/usercert_with_key.pem') }}


### PR DESCRIPTION
If RUCIO_CFG_POLICY_PACKAGE is set, it is used to specify in rucio.cfg the policy package that is to be used.