### PR TITLE
Add flask option for RUCIO_SERVER_TYPE

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -83,6 +83,9 @@ CacheRoot /tmp
 {% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
  Include /opt/rucio/etc/aliases.conf
 {% else %}
+{% if RUCIO_SERVER_TYPE|default('api') == 'flask' %}
+ WSGIScriptAlias /                       /usr/local/lib/python3.6/site-packages/rucio/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
+{% else %}
  WSGIScriptAlias /ping                   /usr/local/lib/python3.6/site-packages/rucio/web/rest/ping.py process-group=rucio application-group=rucio
 {% if RUCIO_SERVER_TYPE|default('api') == 'all' or RUCIO_SERVER_TYPE|default('api') == 'api' %}
  WSGIScriptAlias /accounts               /usr/local/lib/python3.6/site-packages/rucio/web/rest/account.py process-group=rucio application-group=rucio
@@ -111,6 +114,7 @@ CacheRoot /tmp
 {% endif %}
 {% if RUCIO_SERVER_TYPE|default('api') == 'all' or RUCIO_SERVER_TYPE|default('api') == 'trace' %}
  WSGIScriptAlias /traces                 /usr/local/lib/python3.6/site-packages/rucio/web/rest/trace.py process-group=rucio application-group=rucio
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -76,7 +76,11 @@ CacheRoot /tmp
 
  Alias /media                 /usr/local/lib/python3.6/site-packages/rucio/web/ui/media
  Alias /static                /usr/local/lib/python3.6/site-packages/rucio/web/ui/static
+{% if RUCIO_SERVER_TYPE|default('api') == 'flask' %}
+ WSGIScriptAlias /            /usr/local/lib/python3.6/site-packages/rucio/web/ui/flask/main.py
+{% else %}
  WSGIScriptAlias /            /usr/local/lib/python3.6/site-packages/rucio/web/ui/main.py
+{% endif %}
 
 {% if RUCIO_PROXY is defined %}
   ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}


### PR DESCRIPTION
Generate the WSGIScriptAlias for the main flask endpoint when it is selected.
Also add this option for the ui container.