### PR TITLE
Remove listening on port 80 in dev container

### DIFF
--- a/dev/httpd.conf
+++ b/dev/httpd.conf
@@ -39,7 +39,7 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+#Listen 80
 
 #
 # Dynamic Shared Object (DSO) Support


### PR DESCRIPTION
since only 443 is used, which is defined in `rucio.conf`.
Port 80 clashes with graphite when running docker-compose configurations from the main repo in the same network namespace.