### PR TITLE
Remove obsolete dteam VOMS server dteam-voms.hellasgrid.gr

### DIFF
--- a/fts-cron/dteam-voms.hellasgrid.gr
+++ b/fts-cron/dteam-voms.hellasgrid.gr
@@ -1,1 +1,0 @@
-"dteam" "voms.hellasgrid.gr" "15004" "/C=GR/O=HellasGrid/OU=hellasgrid.gr/CN=voms.hellasgrid.gr" "dteam" "24"


### PR DESCRIPTION
Second (first) VOMS server was [removed](https://operations-portal.egi.eu/vo/view/voname/dteam) more than a year ago.