### PR TITLE
Force FTS proxy delegation for dteam VO

### DIFF
--- a/fts-cron/renew_fts_proxy_dteam.sh.j2
+++ b/fts-cron/renew_fts_proxy_dteam.sh.j2
@@ -11,7 +11,7 @@ voms-proxy-init2 -valid 24:00 -cert /tmp/long.proxy -key /tmp/long.proxy -out /t
 {% if RUCIO_FTS_SERVERS is defined %}
 {% set ftses = RUCIO_FTS_SERVERS.split(',') %}
 {% for fts in ftses %}
-fts-rest-delegate --key=/tmp/x509up --cert=/tmp/x509up -s {{ fts }}
+fts-rest-delegate --hours=24 --force --key=/tmp/x509up --cert=/tmp/x509up -s {{ fts }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
fts-rest-delegate / fts-delegate-init don't delegate new proxy unless the old one expiration time is less than 6 hours. On the other hand FTS reject to submit transfer if delegated proxy expiration time is less than 1.5 hours. Both these constants are hardcoded directly in FTS sources.

It is necessary to delegate proxy at least every 4.5 hours otherwise there is a chance you'll not have proxy usable for job transfers or with fts-rest-delegate it is possible force FTS delegation with --force CLI option ... this second option is better, because with default delegation every 6 hours and lifetime 24 hours we can afford few attempts to fail and still have delegated proxy on FTS server with sufficient expiration time.