### PR TITLE
Add use_preparer and other settings necessary for Globus Online

### DIFF
--- a/daemons/rucio.cfg.j2
+++ b/daemons/rucio.cfg.j2
@@ -81,6 +81,10 @@ usercert = {{ RUCIO_CFG_CONVEYOR_USERCERT | default('/opt/rucio/tools/x509up') }
 {% if RUCIO_CFG_CONVEYOR_REQUEST_OIDC_SCOPE is defined %}request_oidc_scope = {{ RUCIO_CFG_CONVEYOR_REQUEST_OIDC_SCOPE }}{% endif %}
 {% if RUCIO_CFG_CONVEYOR_REQUEST_OIDC_AUDIENCE is defined %}request_oidc_audience = {{ RUCIO_CFG_CONVEYOR_REQUEST_OIDC_AUDIENCE }}{% endif %}
 {% if RUCIO_CFG_CONVEYOR_WEBDAV_TRANSFER_MODE is defined %}webdav_transfer_mode = {{ RUCIO_CFG_CONVEYOR_WEBDAV_TRANSFER_MODE }}{% endif %}
+{% if RUCIO_CFG_CONVEYOR_USE_PREPARER is defined %}use_preparer = {{ RUCIO_CFG_CONVEYOR_USE_PREPARER }}{% endif %}
+{% if RUCIO_CFG_CONVEYOR_GLOBUS_AUTH_APP is defined %}globus_auth_app = {{ RUCIO_CFG_CONVEYOR_GLOBUS_AUTH_APP }}{% endif %}
+{% if RUCIO_CFG_CONVEYOR_TRANSFERTYPE is defined %}transfertype = {{ RUCIO_CFG_CONVEYOR_TRANSFERTYPE }}{% endif %}
+{% if RUCIO_CFG_CONVEYOR_FILTER_TRANSFERTOOL is defined %}filter_transfertool = {{ RUCIO_CFG_CONVEYOR_FILTER_TRANSFERTOOL }}{% endif %}
 
 [messaging-fts3]
 port = {{ RUCIO_CFG_MESSAGING_FTS3_PORT | default('61123') }}

--- a/server/rucio.cfg.j2
+++ b/server/rucio.cfg.j2
@@ -74,3 +74,6 @@ idpsecrets = {{ RUCIO_CFG_OIDC_IDPSECRETS | default('/opt/rucio/etc/idpsecrets.j
 
 [api]
 {% if RUCIO_CFG_API_ENDPOINTS is defined %}endpoints = {{ RUCIO_CFG_API_ENDPOINTS }}{% endif %}
+
+[conveyor]
+{% if RUCIO_CFG_CONVEYOR_USE_PREPARER is defined %}use_preparer = {{ RUCIO_CFG_CONVEYOR_USE_PREPARER }}{% endif %}


### PR DESCRIPTION
Add some newer setting which are needed for GlobusOnline transfers. Also include the use_preparer setting in the server since the server has to be aware of this.