### PR TITLE
Add usercert to config/conveyor

### DIFF
--- a/server/rucio.cfg.j2
+++ b/server/rucio.cfg.j2
@@ -77,3 +77,4 @@ idpsecrets = {{ RUCIO_CFG_OIDC_IDPSECRETS | default('/opt/rucio/etc/idpsecrets.j
 
 [conveyor]
 {% if RUCIO_CFG_CONVEYOR_USE_PREPARER is defined %}use_preparer = {{ RUCIO_CFG_CONVEYOR_USE_PREPARER }}{% endif %}
+{% if RUCIO_CFG_CONVEYOR_USERCERT is defined %}usercert = {{ RUCIO_CFG_CONVEYOR_USERCERT }}{% endif %}


### PR DESCRIPTION
The server needs the cert configuration to be able to update rule priority. The secret is now automatically updated after moving to new helm charts : https://github.com/rucio/helm-charts/pull/52 , but we need to update rucio.cfg to take the new secret into account. 