### PR TITLE
Add mariadb-connector-c to dev container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -22,13 +22,18 @@
 
 FROM centos:7
 
+WORKDIR /
+
 RUN yum -y install epel-release && \
     yum -y install https://repo.ius.io/ius-release-el7.rpm && \
     yum -y install gcc httpd mod_ssl mod_auth_kerb python-setuptools python-pip python36u-pip python36-devel \
             python36-mod_wsgi python36-m2crypto gmp-devel krb5-devel git openssl-devel gridsite which libaio memcached \
             nmap-ncat gfal2-all gfal2-util gfal2-python3 fts-rest-cli xrootd-client multitail vim libxml2-devel \
-            openssh-clients \
-            xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel && \
+            openssh-clients xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel && \
+    curl -sSL https://downloads.mariadb.com/Connectors/c/connector-c-3.1.13/mariadb-connector-c-3.1.13-centos7-amd64.tar.gz | tar xzv && \
+    alternatives --install /usr/bin/mariadb_config mariadb_config /mariadb-connector-c-3.1.13-centos7-amd64/bin/mariadb_config 1 && \
+    alternatives --install /usr/lib64/libmariadb.so.3 libmariadb.so.3 /mariadb-connector-c-3.1.13-centos7-amd64/lib/mariadb/libmariadb.so.3 1 && \
+    alternatives --install /usr/lib64/libmariadb.so libmariadb.so /mariadb-connector-c-3.1.13-centos7-amd64/lib/mariadb/libmariadb.so.3 1 && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
Enables integration tests with the [mariadb](https://pypi.org/project/mariadb/) package.