### PR TITLE
docker auto build and push - new workflow

### DIFF
--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -32,25 +32,29 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Get the new Release Tag
+        if: ${{ github.repository_owner == 'maany' }}
         id: release
         shell: bash
         run: | 
           GIT_TAG=$(echo $(git describe --tags --abbrev=0))
-          IMAGE_NAME=$(echo '${{ github.repository_owner }}/rucio-${{ matrix.context_dir }}:release'-$GIT_TAG)
+          IMAGE_TAG=$(echo '${{ github.repository_owner }}/rucio-${{ matrix.context_dir }}:release'-$GIT_TAG)
+          LATEST_TAG=$(echo '${{ github.repository_owner }}/rucio-${{ matrix.context_dir }}:latest')
+          DOCKER_HUB_TAGS=$IMAGE_TAG,$LATEST_TAG
           echo ::set-output name=tag::$GIT_TAG
-          echo ::set-output name=image::$IMAGE_NAME
-          echo $IMAGE_NAME
+          echo ::set-output name=tags::$DOCKER_HUB_TAGS
       
       - name: Prepare Docker Image name
         shell: bash
         run: |
+          echo 'The following images will be pushed'
           echo '${{ steps.release.outputs.image }}'
-      
+          echo '${{ steps.release.outputs.latest }}'
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: ./${{ matrix.context_dir }}
           push: true
-          tags: '${{ steps.release.outputs.image }}'
+          tags: '${{ steps.release.outputs.tags }}'
           build-args: TAG=${{ steps.release.outputs.tag }}

--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -1,11 +1,6 @@
 name: docker-auto-build
 
 on:
-  push:
-    branches:
-      - '!*'
-    tags:
-      - '!*'
   release: 
     types: [created]
 

--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -1,0 +1,56 @@
+name: docker-auto-build
+
+on:
+  push:
+    branches:
+      - '!*'
+    tags:
+      - '!*'
+  release: 
+    types: [created]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        context_dir: ['clients', 'server', 'daemons']
+      fail-fast: false
+    
+    steps:      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Checkout the containers repository
+        uses: actions/checkout@v2
+        
+      - name: Get the new Release Tag
+        id: release
+        shell: bash
+        run: | 
+          GIT_TAG=$(echo $(git describe --tags --abbrev=0))
+          IMAGE_NAME=$(echo '${{ github.repository_owner }}/rucio-${{ matrix.context_dir }}:release'-$GIT_TAG)
+          echo ::set-output name=tag::$GIT_TAG
+          echo ::set-output name=image::$IMAGE_NAME
+          echo $IMAGE_NAME
+      
+      - name: Prepare Docker Image name
+        shell: bash
+        run: |
+          echo '${{ steps.release.outputs.image }}'
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./${{ matrix.context_dir }}
+          push: true
+          tags: '${{ steps.release.outputs.image }}'
+          build-args: TAG=${{ steps.release.outputs.tag }}

--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Get the new Release Tag
-        if: ${{ github.repository_owner == 'maany' }}
         id: release
         shell: bash
         run: | 


### PR DESCRIPTION
close #146

Workflow is triggered when a "New Release" is created.

Currently, it auto builds and publishes to docker hub the images for clients, server and daemons.

Sample run for 1.26.2 release:
Trigger Event: https://github.com/maany/containers/releases/tag/1.26.2 
Workflow run: https://github.com/maany/containers/actions/runs/1190538947 
Published image (server, 1.26.2): https://hub.docker.com/r/maany/rucio-server/tags?page=1&ordering=last_updated
Published image (clients, 1.26.2): https://hub.docker.com/r/maany/rucio-clients/tags?page=1&ordering=last_updated
Published image (daemons, 1.26.2): https://hub.docker.com/r/maany/rucio-daemons/tags?page=1&ordering=last_updated