### PR TITLE
Control server log directory same as UI container

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -73,8 +73,13 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_ENABLE_LOGS|default('False') == 'True' %}
+{% if RUCIO_HTTPD_LOG_DIR is defined %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR}}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR}}/error_log
+{% else %}
  CustomLog logs/access_log combinedrucio
  ErrorLog logs/error_log
+{% endif %}
 {% else %}
  CustomLog /dev/stdout combinedrucio
  ErrorLog /dev/stderr


### PR DESCRIPTION
Mirror in the server container the same ability of the UI container to control the Apache log directory.