### PR TITLE
fix 1.23.x py2 build issues

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -19,8 +19,8 @@ RUN yum install -y python-pip \
     rm -rf /var/cache/yum
 
 # Upgrade pip & setuptools and install Rucio
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --upgrade setuptools && \
+RUN pip install --no-cache-dir --upgrade "pip < 21.0" && \
+    pip install --no-cache-dir --upgrade "setuptools < 45" && \
     pip install --no-cache-dir --pre rucio-clients==$TAG && \
     pip install --no-cache-dir jinja2 j2cli pyyaml
 

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -18,8 +18,8 @@ RUN yum install -y python-pip libaio gcc python-devel.x86_64 openssl-devel.x86_6
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir --upgrade setuptools
+RUN pip install --no-cache-dir --upgrade "pip < 21.0"
+RUN pip install --no-cache-dir --upgrade "setuptools < 45"
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
 RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
 RUN pip install jinja2 j2cli pyyaml

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -28,7 +28,7 @@ RUN rpm -i /tmp/oic.rpm; \
 
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.0/jobber-1.4.0-1.el7.x86_64.rpm
 
-RUN pip install --no-cache-dir --upgrade pip 
+RUN pip install --no-cache-dir --upgrade "pip < 21.0"
 RUN pip install --no-cache-dir --upgrade setuptools
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
 RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -27,8 +27,8 @@ RUN yum install -y httpd mod_wsgi python-pip libaio gcc python-devel.x86_64 mod_
 RUN rpm -i /tmp/oic.rpm; \
     echo "/usr/lib/oracle/12.2/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig
-RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir --upgrade setuptools
+RUN pip install --no-cache-dir --upgrade "pip < 21.0"
+RUN pip install --no-cache-dir --upgrade "setuptools < 45"
 RUN rm -rf /usr/lib/python2.7/site-packages/ipaddress*
 RUN pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
 RUN pip install --no-cache-dir --pre rucio_webui==$TAG


### PR DESCRIPTION
The `clients`, `ui`, `probes` and `init` Dockerfile's try to execute
`pip install --no-cache-dir --upgrade pip`
However, beyond `pip>21`, the new py3 syntax causes these upgrades and hence the auto-builds to fail.

To support py2 in these docker files, it is required to upgrade pip to`< 21` and optionally `setuptools < 45`

Example of the fixed CI run: https://github.com/maany/containers/actions/runs/1805773898