### PR TITLE
Servers & Dev: expose prometheus metrics

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -123,4 +123,5 @@ EXPOSE 443
 ENV PATH $PATH:$RUCIOHOME/bin
 RUN chmod 0600 /root/.ssh/ruciouser_sshkey && \
     chmod 0644 /root/.ssh/ruciouser_sshkey.pub
+ENV prometheus_multiproc_dir /tmp/prometheus
 CMD ["httpd","-D","FOREGROUND"]

--- a/dev/rucio.conf
+++ b/dev/rucio.conf
@@ -35,11 +35,14 @@ WSGIApplicationGroup rucio
  ProxyPassReverse /authproxy  https://localhost
 
  # Rucio WebUI
- Alias  /media          /opt/rucio/lib/rucio/web/ui/media
- Alias  /static         /opt/rucio/lib/rucio/web/ui/static
- WSGIScriptAlias  /ui   /opt/rucio/lib/rucio/web/ui/main.py process-group=rucio application-group=rucio
+ Alias  /media             /opt/rucio/lib/rucio/web/ui/media
+ Alias  /static            /opt/rucio/lib/rucio/web/ui/static
+ WSGIScriptAlias  /ui      /opt/rucio/lib/rucio/web/ui/main.py process-group=rucio application-group=rucio
+
+ # Prometheus Metrics
+ WSGIScriptAlias  /metrics /opt/rucio/lib/rucio/web/rest/metrics.py process-group=rucio application-group=rucio
 
  # Rucio Flask REST API
- WSGIScriptAlias  /     /opt/rucio/lib/rucio/web/rest/main.py process-group=rucio application-group=rucio
+ WSGIScriptAlias  /        /opt/rucio/lib/rucio/web/rest/main.py process-group=rucio application-group=rucio
 
 </VirtualHost>

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -32,6 +32,11 @@ j2 /tmp/rucio.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf.d/rucio.conf
 
 /usr/bin/memcached -u memcached -p 11211 -m 128 -c 1024 &
 
+if [ ! -z "$RUCIO_METRICS_PORT" -a -z "$prometheus_multiproc_dir" ]; then
+    echo "Setting default prometheus_multiproc_dir to /tmp/prometheus"
+    export prometheus_multiproc_dir=/tmp/prometheus
+fi
+
 echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""

--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -25,12 +25,13 @@ WSGIApplicationGroup rucio
 
 CacheEnable disk /
 CacheRoot /tmp
-<VirtualHost *:{{ listen_port}} >
+
+{% macro common_virtual_host_config(port, enable_ssl) %}
 {% if RUCIO_HOSTNAME is defined %}
- ServerName {{ RUCIO_HOSTNAME }}:{{ listen_port }}
+ ServerName {{ RUCIO_HOSTNAME }}:{{ port }}
 {% endif %}
  ServerAdmin {{ RUCIO_SERVER_ADMIN | default('rucio-admin@cern.ch')}}
-{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+{% if enable_ssl %}
  SSLEngine on
  SSLCertificateFile /etc/grid-security/hostcert.pem
  SSLCertificateKeyFile /etc/grid-security/hostkey.pem
@@ -61,12 +62,6 @@ CacheRoot /tmp
  ErrorLog /dev/stderr
 {% endif %}
 
-{% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
- Include /opt/rucio/etc/aliases.conf
-{% else %}
- WSGIScriptAlias /                       /usr/local/lib/python3.6/site-packages/rucio/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
-{% endif %}
-
 {% if RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
  AllowEncodedSlashes on
 {% endif %}
@@ -74,5 +69,22 @@ CacheRoot /tmp
  RewriteEngine on
  RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)
  RewriteRule .* - [F]
+{% endmacro %}
 
+<VirtualHost *:{{ listen_port}} >
+{{ common_virtual_host_config(port=listen_port, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True') }}
+{% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
+ Include /opt/rucio/etc/aliases.conf
+{% else %}
+ WSGIScriptAlias /                       /usr/local/lib/python3.6/site-packages/rucio/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
+{% endif %}
 </VirtualHost>
+
+{% if RUCIO_METRICS_PORT is defined %}
+Listen {{ RUCIO_METRICS_PORT }}
+<VirtualHost *:{{ RUCIO_METRICS_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_METRICS_PORT, enable_ssl=false) }}
+
+ WSGIScriptAlias /metrics                /usr/local/lib/python3.6/site-packages/rucio/web/rest/metrics.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}


### PR DESCRIPTION
https://github.com/rucio/rucio/pull/5158 Introduced the possibility
to collect metrics from servers.

This commit allows to expose those metrics. I use a separate apache
port for servers containers, but expose them on the /metrics path
in the dev container.