### PR TITLE
Servers, UI & Daemons: use exec to run rucio. Closes rucio/rucio#4988

### DIFF
--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -38,7 +38,7 @@ echo "starting daemon with: $RUCIO_DAEMON $RUCIO_DAEMON_ARGS"
 echo ""
 
 if [ -z "$RUCIO_ENABLE_LOGS" ]; then
-    eval "/usr/bin/python3 /usr/local/bin/rucio-$RUCIO_DAEMON $RUCIO_DAEMON_ARGS"
+    exec /usr/bin/python3 "/usr/local/bin/rucio-$RUCIO_DAEMON" "$RUCIO_DAEMON_ARGS"
 else
-    eval "/usr/bin/python3 /usr/local/bin/rucio-$RUCIO_DAEMON $RUCIO_DAEMON_ARGS >> /var/log/rucio/daemon.log 2>> /var/log/rucio/error.log"
+    exec /usr/bin/python3 "/usr/local/bin/rucio-$RUCIO_DAEMON" "$RUCIO_DAEMON_ARGS" >> /var/log/rucio/daemon.log 2>> /var/log/rucio/error.log
 fi

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -53,4 +53,4 @@ fi
 
 pkill httpd || :
 sleep 2
-httpd -D FOREGROUND
+exec httpd -D FOREGROUND

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -32,4 +32,4 @@ echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""
 
-httpd -D FOREGROUND
+exec httpd -D FOREGROUND


### PR DESCRIPTION
This will ensure that signals sent to containers are correctly
delivered to rucio. Otherwise, bash masks the signals and
kubernetes has to sigkill containers to end their execution.