### PR TITLE
adapt webui apache config for http

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -88,6 +88,10 @@ This variable sets the server admin in the apache config.
 
 This variable sets the MPM mode. The default is "event".
 
+### `RUCIO_ENABLE_SSL`
+
+This variable enables the SSLEngine in the Apache Config. The default value is `True`. Set this to `False` if you want to serve only `HTTP` requests. If set to False, you do not need to mount the host certificates when starting the container.
+
 ## `RUCIO_CFG` configuration parameters:
 
 Environment variables can be used to set values for the auto-generated rucio.cfg. The names are derived from the actual names in the configuration file prefixed by `RUCIO_CFG`, e.g., the `default` value in the `database` section becomes `RUCIO_CFG_DATABASE_DEFAULT`.

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -1,8 +1,18 @@
+{% if RUCIO_ENABLE_SSL|default('True') == 'True' %}
+  {% set enable_ssl = 'True' %}
+{% else %}
+  {% set enable_ssl = 'False' %}
+{% endif %}
+
+{% if enable_ssl == 'True' %}
 LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
+{% endif %}
 LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi.so
 
+{% if enable_ssl == 'True' %}
 Listen 443
+{% endif %}
 Listen 80
 
 Header set X-Rucio-Host "%{HTTP_HOST}e"
@@ -20,29 +30,19 @@ LoadModule cache_disk_module modules/mod_cache_disk.so
 CacheEnable disk /
 CacheRoot /tmp
 
+{% macro common_virtual_host_config(port) %}
 {% if RUCIO_HOSTNAME is defined %}
-<VirtualHost *:80>
- ServerName {{ RUCIO_HOSTNAME }}:80
- Redirect / https://{{ RUCIO_HOSTNAME }}/
-</VirtualHost>
-
-<VirtualHost *:443>
- ServerName {{ RUCIO_HOSTNAME }}:443
-{% else %}
-<VirtualHost *:443>
+ ServerName {{ RUCIO_HOSTNAME }}:{{ port }}
 {% endif %}
-{% if RUCIO_SERVER_ADMIN is defined %}
- ServerAdmin {{ RUCIO_SERVER_ADMIN }}
-{% else %}
- ServerAdmin rucio-admin@cern.ch
-{% endif %}
-
+ ServerAdmin {{ RUCIO_SERVER_ADMIN | default('rucio-admin@cern.ch')}}
+{% if enable_ssl == 'True' %}
  SSLEngine on
  SSLCertificateFile /etc/grid-security/hostcert.pem
  SSLCertificateKeyFile /etc/grid-security/hostkey.pem
 {% if RUCIO_CA_PATH is defined %}
  SSLCACertificatePath {{ RUCIO_CA_PATH }}
  SSLCARevocationPath {{ RUCIO_CA_PATH }}
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
 {% else %}
  SSLCACertificateFile /etc/grid-security/ca.pem
 {% endif %}
@@ -55,6 +55,7 @@ CacheRoot /tmp
  SSLProtocol              all -SSLv2 -SSLv3
  #AB: for Security
  SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
 {% if RUCIO_LOG_LEVEL is defined %}
  LogLevel {{ RUCIO_LOG_LEVEL }}
 {% else %}
@@ -73,7 +74,9 @@ CacheRoot /tmp
  CustomLog /dev/stdout combinedrucio
  ErrorLog /dev/stderr
 {% endif %}
+{% endmacro %}
 
+{% macro webui_routes() %}
  Alias /media                 /usr/local/lib/python3.6/site-packages/rucio/web/ui/media
  Alias /static                /usr/local/lib/python3.6/site-packages/rucio/web/ui/static
 {% if RUCIO_SERVER_TYPE|default('api') == 'flask' %}
@@ -83,11 +86,31 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_PROXY is defined %}
-  ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
-  ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+ ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+ ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
 {% endif %}
 {% if RUCIO_AUTH_PROXY is defined %}
-  ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
-  ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+ ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+ ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+{% endif %}
+{% endmacro %}
+
+{% if enable_ssl == 'True' %}
+<VirtualHost *:80>
+{% if RUCIO_HOSTNAME is defined %}
+ ServerName {{ RUCIO_HOSTNAME }}:80
+ Redirect / https://{{ RUCIO_HOSTNAME }}/
 {% endif %}
 </VirtualHost>
+<VirtualHost *:443>
+ {{ common_virtual_host_config(port=443) }}
+ {{ webui_routes() }}
+</VirtualHost>
+{% else %}
+<VirtualHost *:80>
+ {{ common_virtual_host_config(port=80) }}
+ {{ webui_routes() }}
+</VirtualHost>
+{% endif %}
+
+


### PR DESCRIPTION
Output when SSL if enabled ( default behavior)
```
LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so

LoadModule unique_id_module modules/mod_unique_id.so
LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi.so


Listen 443

Listen 80

Header set X-Rucio-Host "%{HTTP_HOST}e"
RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"


LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio


LoadModule authn_core_module modules/mod_authn_core.so
LoadModule cache_disk_module modules/mod_cache_disk.so

CacheEnable disk /
CacheRoot /tmp






<VirtualHost *:80>

 ServerName rucio-devmaany.cern.ch:80
 Redirect / https://rucio-devmaany.cern.ch/

</VirtualHost>
<VirtualHost *:443>
 

 ServerName rucio-devmaany.cern.ch:443

 ServerAdmin rucio-admin@cern.ch

 SSLEngine on
 SSLCertificateFile /etc/grid-security/hostcert.pem
 SSLCertificateKeyFile /etc/grid-security/hostkey.pem

 SSLCACertificateFile /etc/grid-security/ca.pem

 SSLVerifyClient optional_no_ca
 SSLVerifyDepth 10
 SSLOptions +StdEnvVars
 SSLProxyEngine On

 #AB: SSLv3 disable
 SSLProtocol              all -SSLv2 -SSLv3
 #AB: for Security
 SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES


 LogLevel info



 CustomLog /dev/stdout combinedrucio
 ErrorLog /dev/stderr


 
 Alias /media                 /usr/local/lib/python3.6/site-packages/rucio/web/ui/media
 Alias /static                /usr/local/lib/python3.6/site-packages/rucio/web/ui/static

 WSGIScriptAlias /            /usr/local/lib/python3.6/site-packages/rucio/web/ui/main.py



 ProxyPass /proxy             https://https://rucio-atlas.cern.ch
 ProxyPassReverse /proxy      https://https://rucio-atlas.cern.ch


 ProxyPass /authproxy             https://https://auth-rucio.cern.ch
 ProxyPassReverse /authproxy      https://https://auth-rucio.cern.ch


</VirtualHost>

```

Output when SSL is disabled:

```
LoadModule unique_id_module modules/mod_unique_id.so
LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi.so


Listen 80

Header set X-Rucio-Host "%{HTTP_HOST}e"
RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"


LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio


LoadModule authn_core_module modules/mod_authn_core.so
LoadModule cache_disk_module modules/mod_cache_disk.so

CacheEnable disk /
CacheRoot /tmp






<VirtualHost *:80>
 

 ServerName rucio-devmaany.cern.ch:80

 ServerAdmin rucio-admin@cern.ch


 LogLevel info



 CustomLog /dev/stdout combinedrucio
 ErrorLog /dev/stderr


 
 Alias /media                 /usr/local/lib/python3.6/site-packages/rucio/web/ui/media
 Alias /static                /usr/local/lib/python3.6/site-packages/rucio/web/ui/static

 WSGIScriptAlias /            /usr/local/lib/python3.6/site-packages/rucio/web/ui/main.py



 ProxyPass /proxy             https://https://rucio-atlas.cern.ch
 ProxyPassReverse /proxy      https://https://rucio-atlas.cern.ch


 ProxyPass /authproxy             https://https://auth-rucio.cern.ch
 ProxyPassReverse /authproxy      https://https://auth-rucio.cern.ch


</VirtualHost>

```