### PR TITLE
Change GFAL2 python3 binding dependency to new naming convention

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -9,7 +9,7 @@ RUN yum upgrade -y && \
     yum clean all && \
     rm -rf /var/cache/yum
 RUN yum -y install https://repo.ius.io/ius-release-el7.rpm && \
-    yum install -y python36u-pip voms-clients-java gfal2-all gfal2-util gfal2-python3 xrootd-client\
+    yum install -y python36u-pip voms-clients-java gfal2-all gfal2-util python3-gfal2 xrootd-client\
                    nordugrid-arc-client nordugrid-arc-plugins-gfal \
                    nordugrid-arc-plugins-globus nordugrid-arc-plugins-s3 \
                    nordugrid-arc-plugins-xrootd && \

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -36,7 +36,7 @@ RUN python3 -m pip install --no-cache-dir j2cli
 
 # Install dependecies
 RUN yum install -y \
-    gfal2-python3 \
+    python3-gfal2 \
     gfal2-plugin-file \
     gfal2-plugin-gridftp \
     gfal2-plugin-http \


### PR DESCRIPTION
Mihai confirmed that the new naming convention starting from `v1.10.0` is `pythonX-gfal2`.