### PR TITLE
Container PR to work with helm chart for Legacy DN format

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -44,7 +44,11 @@ CacheRoot /tmp
 {% endif %}
  SSLVerifyClient optional_no_ca
  SSLVerifyDepth 10
+{% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
+ SSLOptions +StdEnvVars +LegacyDNStringFormat
+{% else %}
  SSLOptions +StdEnvVars
+{% endif %}
 
 {% if RUCIO_SSL_PROTOCOL is defined %}
  #AB: SSLv3 disable


### PR DESCRIPTION
Enable a helm chart setting to force the DN format to slash separated

Rucio doesn't deal well with the new format (comma separate) if there are commas in the actual DN