### PR TITLE
Fts: use '-y' flag for fts-database-upgrade call

### DIFF
--- a/fts/docker-entrypoint.sh
+++ b/fts/docker-entrypoint.sh
@@ -4,7 +4,7 @@
 /usr/local/bin/wait-for-it.sh -h ftsdb -p 3306 -t 3600
 
 # initialise / upgrade the database
-/usr/share/fts/fts-database-upgrade.py <<< y
+/usr/share/fts/fts-database-upgrade.py -y
 
 # fix Apache configuration
 /usr/bin/sed -i 's/Listen 80/#Listen 80/g' /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
This allows the script to run correctly when in need for multiple
prompts. The current version only works with one user prompt.