### PR TITLE
fix ssh_container

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 # Install OpenSSH
 RUN yum install -y epel-release.noarch
 RUN yum upgrade -y
-RUN yum -y install openssh-server openssh-clients sudo python3-pip && \
+RUN yum -y install gcc openssh-server openssh-clients sudo python3-pip && \
     pip3 install -U dumb-init && \
     yum -y install rsync && \
     yum -y install rclone


### PR DESCRIPTION
The auto-builds failed as installation of the latest `dumb-init` package requires a GCC compiler, which was not available in the ssh container.
