### PR TITLE
Install "nodejs" and "pyright" in dev container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -34,6 +34,9 @@ RUN yum -y install epel-release && \
     alternatives --install /usr/bin/mariadb_config mariadb_config /mariadb-connector-c-3.1.13-centos7-amd64/bin/mariadb_config 1 && \
     alternatives --install /usr/lib64/libmariadb.so.3 libmariadb.so.3 /mariadb-connector-c-3.1.13-centos7-amd64/lib/mariadb/libmariadb.so.3 1 && \
     alternatives --install /usr/lib64/libmariadb.so libmariadb.so /mariadb-connector-c-3.1.13-centos7-amd64/lib/mariadb/libmariadb.so.3 1 && \
+    yum -y install npm nodejs && \
+    npm install --global pyright && \
+    npm cache clean -f && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
This PR installs the `pyright` Python type checker in the development Docker image. This is required for rucio/rucio#5750. 

The tool is installed by first installing `npm` and `nodejs`, then using `npm` to install `pyright`, and then uninstalling `npm` (while leaving `nodejs` installed which is required for running `pyright`). If desired, `npm` can be left behind, but it is currently not used for anything else, so would just increase the size of the final image.
