### PR TITLE
adapt installation and configuration for fts 3.12

### DIFF
--- a/fts/Dockerfile
+++ b/fts/Dockerfile
@@ -6,7 +6,7 @@ RUN curl https://fts-repo.web.cern.ch/fts-repo/fts3-prod-el7.repo > /etc/yum.rep
 RUN curl https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo > /etc/yum.repos.d/dmc-el7.repo
 RUN yum upgrade -y && \
     yum install -y centos-release-scl
-RUN yum install -y mysql multitail gfal2-plugin* fts-server fts-client fts-rest fts-monitoring fts-mysql fts-msg python2-pip
+RUN yum install -y mysql multitail gfal2-plugin* fts-server fts-client fts-rest-server fts-monitoring fts-mysql fts-msg python2-pip
 RUN yum clean all
 
 # Setup FTS security
@@ -25,6 +25,7 @@ RUN chmod +x /usr/share/fts/fts-database-upgrade.py
 
 # Configuration for FTSREST and FTSMON
 COPY fts3rest.conf /etc/httpd/conf.d/fts3rest.conf
+COPY fts3restconfig /etc/fts3/fts3restconfig
 RUN echo "" > /etc/httpd/conf.d/ssl.conf &&\
     echo "" > /etc/httpd/conf.d/autoindex.conf &&\
     echo "" > /etc/httpd/conf.d/userdir.conf &&\

--- a/fts/docker-entrypoint.sh
+++ b/fts/docker-entrypoint.sh
@@ -4,10 +4,14 @@
 /usr/local/bin/wait-for-it.sh -h ftsdb -p 3306 -t 3600
 
 # initialise / upgrade the database
-/usr/share/fts/fts-database-upgrade.py -y
+mysql -h ftsdb -u fts --password=fts fts < $(ls /usr/share/fts-mysql/fts-schema* | sort -t '-' -k '4n' | tail -n 1)
+# TODO: go back to using this script once the fixed it and bundled with the new fts version:
+# /usr/share/fts/fts-database-upgrade.py -y
 
 # fix Apache configuration
 /usr/bin/sed -i 's/Listen 80/#Listen 80/g' /etc/httpd/conf/httpd.conf
+cp /opt/rh/httpd24/root/usr/lib64/httpd/modules/mod_rh-python36-wsgi.so /lib64/httpd/modules
+cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/10-rh-python36-wsgi.conf /etc/httpd/conf.modules.d
 
 # startup the FTS services
 /usr/sbin/fts_server               # main FTS server daemonizes

--- a/fts/fts3rest.conf
+++ b/fts/fts3rest.conf
@@ -56,7 +56,7 @@ Listen 8446
   LogLevel debug
 
   # Send everything to the FTS3 REST interface
-  WSGIScriptAlias / /usr/libexec/fts3/fts3rest.wsgi
+  WSGIScriptAlias / /usr/libexec/fts3rest/fts3rest.wsgi
 
   # Encoded slashes must be kept
   AllowEncodedSlashes NoDecode

--- a/fts/fts3restconfig
+++ b/fts/fts3restconfig
@@ -1,0 +1,75 @@
+SiteName=DOCKER
+
+AuthorizedVO=*
+
+DbType=mysql
+DbUserName=fts
+DbPassword=fts
+DbConnectString=ftsdb/fts
+
+#OpenID parameters
+ValidateAccessTokenOffline=True
+JWKCacheSeconds=86400
+TokenRefreshDaemonIntervalInSeconds=600
+
+#The alias used for the FTS endpoint, will be published as such in the dashboard transfers UI http://dashb-wlcg-transfers.cern.ch/ui/
+Alias=rucio/fts
+
+MonitoringMessaging=false
+
+[sqlalchemy]
+pool_timeout=10
+pool_size=10
+
+[roles]
+Public = vo:transfer;all:datamanagement
+lcgadmin = all:config
+
+# Logging configuration
+[loggers]
+keys = root, routes, fts3rest, sqlalchemy
+
+[handlers]
+keys = console, log_file
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = log_file
+
+[logger_routes]
+level = INFO
+handlers =
+qualname = routes.middleware
+# "level = DEBUG" logs the route matched and routing variables.
+
+[logger_fts3rest]
+level = INFO
+handlers =
+qualname = fts3rest
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+# "level = INFO" logs SQL queries.
+# "level = DEBUG" logs SQL queries and results.
+# "level = WARN" logs neither.  (Recommended for production systems.)
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[handler_log_file]
+class = logging.FileHandler
+args = ('/var/log/fts3rest/fts3rest.log', 'a')
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s,%(msecs)03d %(levelname)-5.5s [%(module)s] %(message)s
+datefmt = %H:%M:%S


### PR DESCRIPTION
This was a major fts release which migrated to using python3 and
had a major re-design of fts rest.
Some scripts are broken because of that. They were not migrated yet.