### PR TITLE
fix prometheus multiproc dir env variable

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -120,6 +120,6 @@ EXPOSE 443
 ENV PATH $PATH:$RUCIOHOME/bin
 RUN chmod 0600 /root/.ssh/ruciouser_sshkey && \
     chmod 0644 /root/.ssh/ruciouser_sshkey.pub
-RUN mkdir /tmp/prometheus
-ENV prometheus_multiproc_dir /tmp/prometheus && chown apache:apache /tmp/prometheus/
+RUN mkdir /tmp/prometheus && chown apache:apache /tmp/prometheus/
+ENV PROMETHEUS_MULTIPROC_DIR /tmp/prometheus
 CMD ["httpd","-D","FOREGROUND"]

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -32,9 +32,9 @@ j2 /tmp/rucio.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf.d/rucio.conf
 
 /usr/bin/memcached -u memcached -p 11211 -m 128 -c 1024 &
 
-if [ ! -z "$RUCIO_METRICS_PORT" -a -z "$prometheus_multiproc_dir" ]; then
-    echo "Setting default prometheus_multiproc_dir to /tmp/prometheus"
-    export prometheus_multiproc_dir=/tmp/prometheus
+if [ ! -z "$RUCIO_METRICS_PORT" -a -z "$PROMETHEUS_MULTIPROC_DIR" -a -z "$prometheus_multiproc_dir" ]; then
+    echo "Setting default PROMETHEUS_MULTIPROC_DIR to /tmp/prometheus"
+    export PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus
 fi
 
 echo "=================== /etc/httpd/conf.d/rucio.conf ========================"


### PR DESCRIPTION
- the lower-case version was deprecated by the upstream library, so switch
  to upper-case
- chown was applied on the wrong line, so the env variable was
  completely wrong