### PR TITLE
Add containers and configuration for the new webui

### DIFF
--- a/webui/.env.default.j2
+++ b/webui/.env.default.j2
@@ -1,0 +1,10 @@
+[rucio_endpoint]
+REACT_APP_RUCIO_HOST = {{ RUCIO_HOST | default('https://rucio-host-not-defined') }}
+
+[login_page_org_images]
+{% if LOGIN_PAGE_IMAGE_PRIMARY is defined %}
+REACT_APP_login_page_image_primary = {{ WEBUI_LOGIN_PAGE_IMAGE_PRIMARY }}
+{% endif %}
+{% if LOGIN_PAGE_IMAGE_SECONDARY is defined %}
+REACT_APP_login_page_image_secondary = {{ WEBUI_LOGIN_PAGE_IMAGE_SECONDARY }}
+{% endif %}

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright European Organization for Nuclear Research (CERN) 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Mayank Sharma, <mayank.sharma@cern.ch>, 2022
+
+FROM node:16-alpine as builder
+ARG TAG
+LABEL stage=builder
+# Install git
+RUN apk update && apk add --no-cache git python3
+# Git Clone the source code for the webui
+RUN git clone --depth 1 -b ${TAG} -- https://github.com/maany/webui.git
+# Set the working directory
+WORKDIR /webui
+# Install dependencies (npm ci makes sure the exact versions in the lockfile gets installed)
+RUN npm ci --legacy-peer-deps 
+# Build the app
+RUN npm run build
+
+
+FROM quay.io/centos/centos:stream8 as production
+LABEL stage=production
+RUN dnf -y update && \
+    dnf -y install httpd mod_ssl python39 git && \
+    dnf clean all
+
+RUN curl https://raw.githubusercontent.com/rucio/rucio/master/tools/merge_rucio_configs.py > /usr/bin/merge_rucio_configs.py
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN python3 -m pip install --no-cache-dir j2cli
+
+# Copy the build output to the web root
+COPY --from=builder /webui/build /var/www/html
+
+COPY robots.txt /var/www/html
+COPY httpd.conf.j2 /tmp/
+COPY rucio.conf.j2 /tmp
+COPY docker-entrypoint.sh /
+
+RUN rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/userdir.conf /etc/httpd/conf.d/ssl.conf
+
+VOLUME /var/log/httpd
+
+EXPOSE 443
+EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -7,38 +7,29 @@
 # Authors:
 # - Mayank Sharma, <mayank.sharma@cern.ch>, 2022
 
-FROM node:16-alpine as builder
-ARG TAG
-LABEL stage=builder
-# Install git
-RUN apk update && apk add --no-cache git python3
-# Git Clone the source code for the webui
-RUN git clone --depth 1 -b ${TAG} -- https://github.com/maany/webui.git
-# Set the working directory
-WORKDIR /webui
-# Install dependencies (npm ci makes sure the exact versions in the lockfile gets installed)
-RUN npm ci --legacy-peer-deps 
-# Build the app
-RUN npm run build
-
-
 FROM quay.io/centos/centos:stream8 as production
+ARG TAG
 LABEL stage=production
 RUN dnf -y update && \
-    dnf -y install httpd mod_ssl python39 git && \
+    dnf -y module reset nodejs && \
+    dnf -y module enable nodejs:16 && \
+    dnf -y module install nodejs:16/common && \
+    dnf -y install httpd mod_ssl python39 git procps && \
     dnf clean all
 
-RUN curl https://raw.githubusercontent.com/rucio/rucio/master/tools/merge_rucio_configs.py > /usr/bin/merge_rucio_configs.py
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir j2cli
 
-# Copy the build output to the web root
-COPY --from=builder /webui/build /var/www/html
+WORKDIR /opt/rucio/webui
+RUN curl https://raw.githubusercontent.com/rucio/rucio/master/tools/merge_rucio_configs.py --output /opt/rucio/merge_rucio_configs.py
+RUN git clone --depth 1 -b ${TAG} -- https://github.com/maany/webui.git /opt/rucio/webui
+RUN npm ci --legacy-peer-deps 
 
 COPY robots.txt /var/www/html
 COPY httpd.conf.j2 /tmp/
 COPY rucio.conf.j2 /tmp
 COPY docker-entrypoint.sh /
+COPY .env.default.j2 /tmp/
 
 RUN rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/userdir.conf /etc/httpd/conf.d/ssl.conf
 

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,14 @@
+# Rucio - Scientific Data Management
+This repository contains the Docker container for the new React Based WebUI. For the older WebUI, please go [here](https://github.com/rucio/containers/tree/master/ui).
+
+## (React WebUI Container)
+
+Rucio is a software framework that provides functionality to organize, manage, and access large volumes of scientific data using customisable policies. The data can be spread across globally distributed locations and across heterogeneous data centers, uniting different storage and network technologies as a single federated entity. Rucio offers advanced features such as distributed data recovery or adaptive replication, and is highly scalable, modular, and extensible. Rucio has been originally developed to meet the requirements of the high-energy physics experiment ATLAS, and is continuously extended to support LHC experiments and other diverse scientific communities.
+
+## Documentation
+
+Instructions to use and deploy the docker image for the new Rucio WebUI can be found [here](https://rucio.cern.ch/documentation/installing_webui). General information and latest documentation about Rucio can be found [here](https://rucio.cern.ch/documentation/).
+
+## Developers
+
+For information on how to contribute to Rucio, please refer and follow our [CONTRIBUTING](<https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst>) guidelines.

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,14 +1,48 @@
 # Rucio - Scientific Data Management
-This repository contains the Docker container for the new React Based WebUI. For the older WebUI, please go [here](https://github.com/rucio/containers/tree/master/ui).
-
-## (React WebUI Container)
 
 Rucio is a software framework that provides functionality to organize, manage, and access large volumes of scientific data using customisable policies. The data can be spread across globally distributed locations and across heterogeneous data centers, uniting different storage and network technologies as a single federated entity. Rucio offers advanced features such as distributed data recovery or adaptive replication, and is highly scalable, modular, and extensible. Rucio has been originally developed to meet the requirements of the high-energy physics experiment ATLAS, and is continuously extended to support LHC experiments and other diverse scientific communities.
 
+## React WebUI Container
+
+This repository contains the Docker container and configuration file templates for the new [React Based WebUI](https://github.com/rucio/webui). For the older WebUI, please go [here](https://github.com/rucio/containers/tree/master/ui).
+
 ## Documentation
 
-Instructions to use and deploy the docker image for the new Rucio WebUI can be found [here](https://rucio.cern.ch/documentation/installing_webui). General information and latest documentation about Rucio can be found [here](https://rucio.cern.ch/documentation/).
+Instructions to use and deploy the docker image for the new Rucio WebUI can be found [here](https://rucio.cern.ch/documentation/installing_webui). General information and latest documentation about Rucio can be found [here](https://rucio.cern.ch/documentation/). 
 
 ## Developers
 
 For information on how to contribute to Rucio, please refer and follow our [CONTRIBUTING](<https://github.com/rucio/rucio/blob/master/CONTRIBUTING.rst>) guidelines.
+
+The new WebUI is a single-page React app, therefore, `httpd` is only used for providing `TLS Termination` and `SSL Client Certificate Verification` capabilities.
+
+The configuration parameters for the react app itself are included in the `.env.default.j2` template. In the webui repository, these environment variables are present in the [.env.template](https://github.com/rucio/webui/blob/master/.env.template) file. Please make sure that all the required environment variables required by the react application can be configured via the `.env.default.j2` template.
+
+The React app gets built into a static website after running `npm build` in the `docker-entrypoint.sh`. The build process also embeds all environment variables in the final processed output of `.env.default.j2` file (i.e. /opt/rucio/webui/.env inside the container) in the source of the static web application. When httpd serves the webui, it returns the source of the static web application. Therefore, it is highly recommended to **NOT specify any secrets via the environment variables used in .env.default.j2 configuration template**.
+
+The Dockerfile fetches the source code from a **tagged release of the webui repository ( no node package is pushed to npm)**. The tagged release is specified by the `--build-arg TAG=<value>` argument of the `docker build` command.
+
+The file `rucio.conf.j2` specifies webui specific configuration for `httpd`. The status of the `x509` certificate veritication is embedded into the `X-SSL-Client-S-DN` and `X-SSL-Client-Verify` response headers. These headers are used by the webui to figure out if x509 was used as an authentication method and whether a valid client certificate was presented.
+
+For x509 Client Certificate Vertification, the initial idea was to define a new Location in httpd config under the virtual host listening at port 443
+```
+<Location /auth/x509> 
+ SSLVerifyClient optional_no_ca
+ SSLVerifyDepth 10
+</Location>
+```
+This would allow the end-users to click on the `x509 Authentication` button in the webui login page, which would then initiate the client certificate request and vertification process.
+
+While, this is a totally valid httpd configuration, most browsers, at the time of writing this document, do not support [`post-handshake`](https://stackoverflow.com/questions/53062504/apache-2-4-37-with-openssl-1-1-1-cannot-perform-post-handshake-authentication) authentication. Therefore, the `SSLVerifyClient` directive must be used in the <VirtualHost *:443> directive.
+
+In case this changes in future, please coordinate with the developers of the webui to adapt to the `post-handshake` authentication scenario.
+
+## Enabling docker auto builds
+Once the new webui is ready to be included as part of the main release process of Rucio, it must be added to the docker auto build and push workflow defined in this repository.
+
+To do so, please add
+```
+'webui, prepend-rucio, prepend-release, push-tagged, push-latest'
+```
+to the [build context](
+https://github.com/rucio/containers/blob/df0d2a40a24db32523ed218b7e340616832f459a/.github/workflows/docker-auto-build.yml#L13-L28).

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -13,19 +13,22 @@ echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""
 
+j2 /tmp/.env.default.j2 | sed '/^\s*$/d' > /opt/rucio/webui/.env.default
 
-if [ -f /opt/rucio/etc/rucio.cfg ]; then
-    echo "rucio.cfg already mounted."
+if [ -f /opt/rucio/webui/.env ]; then
+    echo "/opt/rucio/webui/.env already mounted."
 else
-    echo "rucio.cfg not found. will generate one."
-    python3 /usr/bin/tools/merge_rucio_configs.py \
+    echo "/opt/rucio/webui/.env not found. will generate one."
+    python3 /opt/rucio/merge_rucio_configs.py \
+        -s /opt/rucio/webui/.env.default $RUCIO_OVERRIDE_CONFIGS \
         --use-env \
-        -d /var/www/html/etc/rucio.cfg
+        -d /opt/rucio/webui/.env
 fi
 
-# echo "=================== /opt/rucio/etc/rucio.cfg ============================"
-# cat /opt/rucio/etc/rucio.cfg
-# echo ""
+echo "=================== /opt/rucio/webui/.env ========================"
+cat /opt/rucio/webui/.env
+echo ""
 
-sleep infinity
+npm run build
+cp -rfn /opt/rucio/webui/build/* /var/www/html/
 exec httpd -D FOREGROUND

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+j2 /tmp/httpd.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf/httpd.conf
+
+echo "=================== /etc/httpd/conf/httpd.conf ========================"
+cat /etc/httpd/conf/httpd.conf
+echo ""
+
+
+j2 /tmp/rucio.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf.d/rucio.conf
+
+echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
+cat /etc/httpd/conf.d/rucio.conf
+echo ""
+
+
+if [ -f /opt/rucio/etc/rucio.cfg ]; then
+    echo "rucio.cfg already mounted."
+else
+    echo "rucio.cfg not found. will generate one."
+    python3 /usr/bin/tools/merge_rucio_configs.py \
+        --use-env \
+        -d /var/www/html/etc/rucio.cfg
+fi
+
+# echo "=================== /opt/rucio/etc/rucio.cfg ============================"
+# cat /opt/rucio/etc/rucio.cfg
+# echo ""
+
+sleep infinity
+exec httpd -D FOREGROUND

--- a/webui/httpd.conf.j2
+++ b/webui/httpd.conf.j2
@@ -18,6 +18,10 @@ DocumentRoot "/var/www/html"
 
 <Directory "/var/www/html">
     Options Indexes FollowSymLinks
+    Options -MultiViews
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.html [QSA,L]
     AllowOverride None
     Require all granted
 </Directory>

--- a/webui/httpd.conf.j2
+++ b/webui/httpd.conf.j2
@@ -1,0 +1,103 @@
+ServerRoot "/etc/httpd"
+Include conf.modules.d/*.conf
+User apache
+Group apache
+ServerAdmin root@localhost
+
+<Directory />
+    AllowOverride None
+    Require all denied
+</Directory>
+
+DocumentRoot "/var/www/html"
+
+<Directory "/var/www">
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<Directory "/var/www/html">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog "logs/error_log"
+
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+    CustomLog "logs/access_log" combined
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+</IfModule>
+
+<Directory "/var/www/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule mime_module>
+    TypesConfig /etc/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+    AddType text/html .shtml
+    AddOutputFilter INCLUDES .shtml
+</IfModule>
+AddDefaultCharset UTF-8
+
+<IfModule mime_magic_module>
+    MIMEMagicFile conf/magic
+</IfModule>
+
+EnableSendfile on
+# Load config files in the "/etc/httpd/conf.d" directory, if any.
+IncludeOptional conf.d/*.conf
+
+Timeout {{ RUCIO_HTTPD_TIMEOUT | default('60') }}
+
+{% if RUCIO_HTTPD_MPM_MODE is defined and RUCIO_HTTPD_MPM_MODE == "prefork" -%}
+StartServers           {{ RUCIO_HTTPD_START_SERVERS | default('8') }}
+MinSpareServers        {{ RUCIO_HTTPD_MIN_SPARE_SERVERS | default('5') }}
+MaxSpareServers        {{ RUCIO_HTTPD_MAX_SPARE_SERVERS | default('20') }}
+ServerLimit            {{ RUCIO_HTTPD_SERVER_LIMIT | default('256') }}
+MaxClients             {{ RUCIO_HTTPD_MAX_CLIENTS | default('256') }}
+MaxRequestsPerChild    {{ RUCIO_HTTPD_MAX_REQUESTS_PER_CHILD | default('4000') }}
+{% elif RUCIO_HTTPD_MPM_MODE is defined and RUCIO_HTTPD_MPM_MODE == "worker" -%}
+StartServers           {{ RUCIO_HTTPD_START_SERVERS | default('1') }}
+MaxClients             {{ RUCIO_HTTPD_MAX_CLIENTS | default('20') }}
+MinSpareThreads        {{ RUCIO_HTTPD_MIN_SPARE_THREADS | default('1') }}
+MaxSpareThreads        {{ RUCIO_HTTPD_MAX_SPARE_THREADS | default('20') }}
+ThreadsPerChild        {{ RUCIO_HTTPD_THREADS_PER_CHILD | default('5') }}
+MaxRequestsPerChild    {{ RUCIO_HTTPD_MAX_REQUESTS_PER_CHILD | default('8192') }}
+{% else %}
+KeepAlive              {{ RUCIO_HTTPD_KEEP_ALIVE | default('On') }}
+KeepAliveTimeout       {{ RUCIO_HTTPD_KEEP_ALIVE_TIMEOUT | default('5') }}
+MaxKeepAliveRequests   {{ RUCIO_HTTPD_MAX_KEEP_ALIVE_REQUESTS | default('128') }}
+ServerLimit            {{ RUCIO_HTTPD_SERVER_LIMIT | default('10') }}
+StartServers           {{ RUCIO_HTTPD_START_SERVERS | default('4') }}
+ThreadLimit            {{ RUCIO_HTTPD_THREADS_LIMIT | default('128') }}
+ThreadsPerChild        {{ RUCIO_HTTPD_THREADS_PER_CHILD | default('128') }}
+MinSpareThreads        {{ RUCIO_HTTPD_MIN_SPARE_THREADS | default('256') }}
+MaxSpareThreads        {{ RUCIO_HTTPD_MAX_SPARE_THREADS | default('512') }}
+MaxRequestWorkers      {{ RUCIO_HTTPD_MAX_REQUEST_WORKERS | default('1280') }}
+MaxConnectionsPerChild {{ RUCIO_HTTPD_MAX_CONNECTIONS_PER_CHILD | default('2048') }}
+{% endif %} 

--- a/webui/robots.txt
+++ b/webui/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/webui/rucio.conf.j2
+++ b/webui/rucio.conf.j2
@@ -44,22 +44,6 @@
 {% endif %}
 {% endmacro %}
 
-{% macro webui_routes() %}
-  Options -MultiViews
-  RewriteEngine On
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteRule ^ index.html [QSA,L]
-{% if RUCIO_PROXY is defined %}
- ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
- ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
-{% endif %}
-{% if RUCIO_AUTH_PROXY is defined %}
- ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
- ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
-{% endif %}
-{% endmacro %}
-
-
 {% if RUCIO_ENABLE_SSL|default('True') == 'True' %}
   {% set enable_ssl = 'True' %}
 {% else %}
@@ -87,7 +71,6 @@ LogFormat "{{ RUCIO_LOG_FORMAT }}" combinedrucio
 LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio
 {% endif %}
 
-# Virtual Hosts on port 80 & 443 when SSL is enabled
 {% if enable_ssl == 'True' %}
 <VirtualHost *:80>
 
@@ -100,15 +83,13 @@ LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"
 <VirtualHost *:443>
 
  {{ common_virtual_host_config(port=443) }}
- {{ webui_routes() }}
 
 </VirtualHost>
 
 {% else %}
-#
+
 <VirtualHost *:80>
  {{ common_virtual_host_config(port=80) }}
- {{ webui_routes() }}
 </VirtualHost>
 {% endif %}
 

--- a/webui/rucio.conf.j2
+++ b/webui/rucio.conf.j2
@@ -1,0 +1,114 @@
+{% macro common_virtual_host_config(port) %}
+{% if RUCIO_HOSTNAME is defined %}
+ ServerName {{ RUCIO_HOSTNAME }}:{{ port }}
+{% endif %}
+ ServerAdmin {{ RUCIO_SERVER_ADMIN | default('rucio-admin@cern.ch')}}
+{% if enable_ssl == 'True' %}
+ SSLEngine on
+ SSLCertificateFile /etc/grid-security/hostcert.pem
+ SSLCertificateKeyFile /etc/grid-security/hostkey.pem
+{% if RUCIO_CA_PATH is defined %}
+ SSLCACertificatePath {{ RUCIO_CA_PATH }}
+ SSLCARevocationPath {{ RUCIO_CA_PATH }}
+ SSLCARevocationCheck {{ RUCIO_CA_REVOCATION_CHECK | default('chain') }}
+{% else %}
+ SSLCACertificateFile /etc/grid-security/ca.pem
+{% endif %}
+ SSLVerifyClient optional_no_ca
+ SSLVerifyDepth 10
+ SSLOptions +StdEnvVars
+ SSLProxyEngine On
+
+ #AB: SSLv3 disable
+ SSLProtocol              all -SSLv2 -SSLv3
+ #AB: for Security
+ SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
+{% if RUCIO_LOG_LEVEL is defined %}
+ LogLevel {{ RUCIO_LOG_LEVEL }}
+{% else %}
+ LogLevel info
+{% endif %}
+
+{% if RUCIO_ENABLE_LOGS|default('False') == 'True' %}
+{% if RUCIO_HTTPD_LOG_DIR is defined %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR}}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR}}/error_log
+{% else %}
+ CustomLog logs/access_log combinedrucio
+ ErrorLog logs/error_log
+{% endif %}
+{% else %}
+ CustomLog /dev/stdout combinedrucio
+ ErrorLog /dev/stderr
+{% endif %}
+{% endmacro %}
+
+{% macro webui_routes() %}
+  Options -MultiViews
+  RewriteEngine On
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteRule ^ index.html [QSA,L]
+{% if RUCIO_PROXY is defined %}
+ ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+ ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+{% endif %}
+{% if RUCIO_AUTH_PROXY is defined %}
+ ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+ ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+{% endif %}
+{% endmacro %}
+
+
+{% if RUCIO_ENABLE_SSL|default('True') == 'True' %}
+  {% set enable_ssl = 'True' %}
+{% else %}
+  {% set enable_ssl = 'False' %}
+{% endif %}
+
+{% if enable_ssl == 'True' %}
+LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
+Listen 443
+{% endif %}
+LoadModule unique_id_module modules/mod_unique_id.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule cache_disk_module modules/mod_cache_disk.so
+
+CacheEnable disk /
+CacheRoot /tmp
+Listen 80
+
+Header set X-Rucio-Host "%{HTTP_HOST}e"
+RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"
+
+{% if RUCIO_LOG_FORMAT is defined %}
+LogFormat "{{ RUCIO_LOG_FORMAT }}" combinedrucio
+{% else %}
+LogFormat "%h\t%t\t%{X-Rucio-Forwarded-For}i\t%T\t%D\t\"%{X-Rucio-Auth-Token}i\"\t%{X-Rucio-RequestId}i\t%{X-Rucio-Client-Ref}i\t\"%r\"\t%>s\t%b" combinedrucio
+{% endif %}
+
+# Virtual Hosts on port 80 & 443 when SSL is enabled
+{% if enable_ssl == 'True' %}
+<VirtualHost *:80>
+
+{% if RUCIO_HOSTNAME is defined %}
+ ServerName {{ RUCIO_HOSTNAME }}:80
+ Redirect / https://{{ RUCIO_HOSTNAME }}/
+{% endif %}
+</VirtualHost>
+
+<VirtualHost *:443>
+
+ {{ common_virtual_host_config(port=443) }}
+ {{ webui_routes() }}
+
+</VirtualHost>
+
+{% else %}
+#
+<VirtualHost *:80>
+ {{ common_virtual_host_config(port=80) }}
+ {{ webui_routes() }}
+</VirtualHost>
+{% endif %}
+

--- a/webui/rucio.conf.j2
+++ b/webui/rucio.conf.j2
@@ -23,6 +23,8 @@
  SSLProtocol              all -SSLv2 -SSLv3
  #AB: for Security
  SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+ Header set X-SSL-Client-S-DN "expr=%{SSL_CLIENT_S_DN}"
+ Header set X-SSL-Verify "expr=%{SSL_CLIENT_VERIFY}"
 {% endif %}
 {% if RUCIO_LOG_LEVEL is defined %}
  LogLevel {{ RUCIO_LOG_LEVEL }}


### PR DESCRIPTION
Add the `Dockerfile`, `docker-entrypoint` and configuration file templates for building a production container for the new React based webui.

The webui can operate with/without TLS Termination i.e. it can be served as a pure HTTP app, however, in that case x509 certificate verification is disabled.
