### PR TITLE
Added Multi-Vo functionality to FTS cron job

### DIFF
--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -41,6 +41,7 @@ ADD renew_fts_proxy.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_atlas.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_dteam.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_tutorial.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_multi_vo.sh.j2 /opt/rucio/fts-delegate/
 ADD rucio_ca.pem /etc/grid-security/certificates/
 
 ADD dteam* /etc/vomses/

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -41,6 +41,7 @@ ADD renew_fts_proxy.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_atlas.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_dteam.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_tutorial.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_multi_vo.sh.j2 /opt/rucio/fts-delegate/
 ADD rucio_ca.pem /etc/grid-security/certificates/
 
 ADD dteam* /etc/vomses/

--- a/fts-cron/docker-entrypoint.sh
+++ b/fts-cron/docker-entrypoint.sh
@@ -6,6 +6,9 @@ then
 elif [[ $RUCIO_VO == 'dteam' ]]
 then
     j2 /opt/rucio/fts-delegate/renew_fts_proxy_dteam.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
+elif [[ $RUCIO_VO == 'multi_vo' ]]
+then
+    j2 /opt/rucio/fts-delegate/renew_fts_proxy_multi_vo.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh
 elif [[ $RUCIO_VO == 'tutorial' ]]
 then
     j2 /opt/rucio/fts-delegate/renew_fts_proxy_tutorial.sh.j2 > /opt/rucio/fts-delegate/renew_fts_proxy.sh

--- a/fts-cron/renew_fts_proxy_multi_vo.sh.j2
+++ b/fts-cron/renew_fts_proxy_multi_vo.sh.j2
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+{% if RUCIO_FTS_VOMSES is defined %}
+{% set vomses = RUCIO_FTS_VOMSES.split(',') %}
+{% for voms in vomses %}
+
+printf "=================== {{ voms }} Renewal =========================\n\n"
+
+# We have to copy the certificates because we cannot change permissions on them as mounted secrets and voms-proxy is particular about permissions
+mkdir /tmp/{{ voms }}/
+cp /opt/rucio/certs/{{ voms }}/{{ RUCIO_LONG_PROXY }} /tmp/{{ voms }}/long.proxy
+chmod 400 /tmp/{{ voms }}/long.proxy
+
+# Generate a proxy with the voms extension if requested
+voms-proxy-init2 -valid 24:00 -cert /tmp/{{ voms }}/long.proxy -key /tmp/{{ voms }}/long.proxy -out /tmp/x509up_{{ voms }} -voms {{ voms }} -rfc -timeout 5
+
+# Delegate the proxy to the requested servers
+{% if RUCIO_FTS_SERVERS is defined %}
+{% set ftses = RUCIO_FTS_SERVERS.split(',') %}
+{% for fts in ftses %}
+fts-rest-delegate --hours=24 --force --key=/tmp/x509up_{{ voms }} --cert=/tmp/x509up_{{ voms }} -s {{ fts }}
+{% endfor %}
+{% endif %}
+
+# Create the corresponding kubernetes secrets if asked
+{% if RUCIO_FTS_SECRETS is defined %}
+{% set secrets = RUCIO_FTS_SECRETS.split(',') %}
+{% for secret in secrets %}
+kubectl create secret generic  {{ secret }}-{{ voms }} --from-file=/tmp/x509up_{{ voms }} --dry-run=client -o yaml | kubectl apply --validate=false  -f  -
+{% endfor %}
+{% endif %}
+
+printf "\n=============== {{ voms }} Renewal Complete ====================\n\n"
+
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Created a new multi-vo script, `renew_fts_proxy_multi_vo.sh.j2`, which allows the renew fts proxy cron job to renew several proxies at once for different VOs.

Made changes to the `Dockerfile` to add the new script to the container and added selection condition to `docker-entrypoint` to select the multi vo script.