### PR TITLE
pin requests version for py2 fts-rest-client in dev container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -64,7 +64,7 @@ RUN python3 -m pip install --no-cache --upgrade pip && \
     ln -s $RUCIOHOME/lib/rucio /usr/local/lib/python3.6/site-packages/rucio
 
 #additional configuration for fts-rest-cli
-RUN pip2 install requests 
+RUN pip2 install requests==2.22.0
 
 COPY .pep8 .pep8
 COPY .flake8 .flake8


### PR DESCRIPTION
Integration tests for 1.26 releases fail: https://github.com/rucio/rucio/actions/runs/3461834194/jobs/5779940105
```
==========================
    Unsupported Python version

The integration tests for 1.26 releases fail with the following error
==========================
    This version of Requests requires at least Python 3.7, but
    you're trying to install it on Python 2.7. To resolve this,
    consider upgrading to a supported Python version.

    If you can't upgrade your Python version, you'll need to
    pin to an older version of Requests (<2.28).
```

This commit pins the version of the requests package needed by the python2 dependencies (fts-rest-client)