### PR TITLE
add capath to tutorial fts_rest_delegate

### DIFF
--- a/fts-cron/renew_fts_proxy_tutorial.sh.j2
+++ b/fts-cron/renew_fts_proxy_tutorial.sh.j2
@@ -4,6 +4,6 @@
 {% if RUCIO_FTS_SERVERS is defined %}
 {% set ftses = RUCIO_FTS_SERVERS.split(',') %}
 {% for fts in ftses %}
-fts-rest-delegate -v -f -H 9999 --key=/opt/rucio/keys/userkey.pem --cert=/opt/rucio/certs/usercert.pem -s {{ fts }}
+fts-rest-delegate -v -f -H 9999 --key=/opt/rucio/keys/userkey.pem --cert=/opt/rucio/certs/usercert.pem --capath /etc/grid-security/certificates/rucio_ca.pem -s {{ fts }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
FTS client was updated to 3.12, which uses a python client now, so CA certificates from grid-security aren't used automatically anymore.