### PR TITLE
enhancement: install cern ca fix #223

### DIFF
--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -1,5 +1,21 @@
 FROM centos:7
 
+# Install CERN CA
+ADD ca.repo /etc/yum.repos.d/ca.repo
+
+RUN yum install -y epel-release.noarch http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN yum update -y && \
+    yum upgrade -y && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+RUN yum -y install ca-certificates.noarch lcg-CA ca_* \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 # Install XrootD
 RUN yum install -y epel-release.noarch
 RUN yum upgrade -y

--- a/xrootd/ca.repo
+++ b/xrootd/ca.repo
@@ -1,0 +1,6 @@
+[carepo]
+name=IGTF CA Repository
+baseurl=http://linuxsoft.cern.ch/mirror/repository.egi.eu/sw/production/cas/1/current/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-EUGridPMA-RPM-3


### PR DESCRIPTION
Add CERN CA installation to the Dockerfile of `xrootd` container for CERN certs to be trusted.