### PR TITLE
fts-cron: allow to disable fetch_crl

### DIFF
--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -42,6 +42,7 @@ ADD renew_fts_proxy_atlas.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_dteam.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_tutorial.sh.j2 /opt/rucio/fts-delegate/
 ADD renew_fts_proxy_multi_vo.sh.j2 /opt/rucio/fts-delegate/
+ADD renew_fts_proxy_escape.sh.j2 /opt/rucio/fts-delegate/
 ADD rucio_ca.pem /etc/grid-security/certificates/
 
 ADD dteam* /etc/vomses/

--- a/fts-cron/docker-entrypoint.sh
+++ b/fts-cron/docker-entrypoint.sh
@@ -27,9 +27,12 @@ echo "=================== /renew_fts_proxy.sh ========================"
 cat /opt/rucio/fts-delegate/renew_fts_proxy.sh
 echo ""
 
-echo "=================== Updating certificate environment ========================"
 
-/usr/sbin/fetch-crl -v --define httptimeout=3 || true
+if [ -z "$FETCH_CRL" -o "$FETCH_CRL" = "True" ]; then
+    echo "=================== Updating certificate environment ========================"
+
+    /usr/sbin/fetch-crl -v --define httptimeout=3 || true
+fi
 
 echo "=================== Delegating ========================"
 


### PR DESCRIPTION
For people who mount the final CRLs directly into the container.

If not explicitly disabled, default to the old behavior of
fetching the CRLs.