### PR TITLE
servers: build openssl3.1 for alma9 daemons

### DIFF
--- a/daemons/alma9.Dockerfile
+++ b/daemons/alma9.Dockerfile
@@ -4,6 +4,21 @@
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+FROM almalinux:9 as rpm_builder
+    RUN dnf upgrade -y
+    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch
+    RUN yum-config-manager --enable crb
+    # BUILD and install openssl 3.1
+    ADD openssl.spec    /root/rpmbuild/SPECS/openssl.spec
+    RUN yum-builddep -y /root/rpmbuild/SPECS/openssl.spec
+    RUN spectool -g     /root/rpmbuild/SPECS/openssl.spec --directory /root/rpmbuild/SOURCES/
+    RUN rpmbuild -bb    /root/rpmbuild/SPECS/openssl.spec
+    RUN dnf install -y  /root/rpmbuild/RPMS/*/*
+    # REBUILD davix to use openssl 3.1
+    RUN yumdownloader --source davix
+    RUN yum-builddep -y --srpm davix*.src.rpm
+    RUN rpmbuild --rebuild davix-*.src.rpm
+
 FROM almalinux:9
 
 ARG TAG
@@ -47,6 +62,8 @@ ADD start-daemon.sh /
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 RUN mkdir /var/log/rucio
+
+COPY --from=rpm_builder /root/rpmbuild/RPMS/x86_64/*.rpm /tmp/rpms/
 
 VOLUME /var/log/rucio
 VOLUME /opt/rucio/etc

--- a/daemons/openssl.spec
+++ b/daemons/openssl.spec
@@ -1,0 +1,163 @@
+# Heavily inspired by the spec file from the alma9 openssl source rpm.
+# All custom patches where removed because they don't apply on 3.1
+# The library is installed as a separate .so file and can co-exist
+# with openssl 3.0. So only packages which are re-built with the
+# openssl31-devel package installed will be impacted.
+
+%define soversion 3.1
+%define _unpackaged_files_terminate_build 0
+
+%global _performance_build 1
+
+Summary: Utilities from the general purpose cryptography library with TLS implementation
+Name:    openssl31
+Version: 3.1.0
+Release: 1
+Source:  https://www.openssl.org/source/openssl-%{version}.tar.gz
+
+License: ASL 2.0
+URL: http://www.openssl.org/
+BuildRequires: gcc g++
+BuildRequires: coreutils, perl-interpreter, sed, zlib-devel, /usr/bin/cmp
+BuildRequires: lksctp-tools-devel
+BuildRequires: /usr/bin/rename
+BuildRequires: /usr/bin/pod2man
+BuildRequires: /usr/sbin/sysctl
+BuildRequires: perl(Test::Harness), perl(Test::More), perl(Math::BigInt)
+BuildRequires: perl(Module::Load::Conditional), perl(File::Temp)
+BuildRequires: perl(Time::HiRes), perl(IPC::Cmd), perl(Pod::Html), perl(Digest::SHA)
+BuildRequires: perl(FindBin), perl(lib), perl(File::Compare), perl(File::Copy), perl(bigint)
+BuildRequires: git-core
+Requires: coreutils
+Requires: %{name}-libs = %{version}-%{release}
+
+%description
+The OpenSSL toolkit provides support for secure communications between
+machines. OpenSSL includes a certificate management tool and shared
+libraries which provide various cryptographic algorithms and
+protocols.
+
+%package libs
+Summary: A general purpose cryptography library with TLS implementation
+Requires: ca-certificates >= 2008-5
+Requires: crypto-policies >= 20180730
+Recommends: openssl-libs
+
+%description libs
+OpenSSL is a toolkit for supporting cryptography. The openssl-libs
+package contains the libraries that are used by various applications which
+support cryptographic algorithms and protocols.
+
+%package devel
+Summary: Files for development of applications which will use OpenSSL
+Requires: %{name}-libs = %{version}-%{release}
+Requires: pkgconfig
+Provides: openssl-devel
+
+%description devel
+OpenSSL is a toolkit for supporting cryptography. The openssl-devel
+package contains include files needed to develop applications which
+support various cryptographic algorithms and protocols.
+
+%prep
+%autosetup -S git -n openssl-%{version}
+
+%build
+sslarch=%{_os}-%{_target_cpu}
+sslflags=enable-ec_nistp_64_gcc_128
+
+# Add -Wa,--noexecstack here so that libcrypto's assembler modules will be
+# marked as not requiring an executable stack.
+# Also add -DPURIFY to make using valgrind with openssl easier as we do not
+# want to depend on the uninitialized memory as a source of entropy anyway.
+RPM_OPT_FLAGS="$RPM_OPT_FLAGS -Wa,--noexecstack -Wa,--generate-missing-build-notes=yes -DPURIFY $RPM_LD_FLAGS"
+
+export HASHBANGPERL=/usr/bin/perl
+
+# ia64, x86_64, ppc are OK by default
+# Configure the build tree.  Override OpenSSL defaults with known-good defaults
+# usable on all platforms.  The Configure script already knows to use -fPIC and
+# RPM_OPT_FLAGS, so we can skip specifiying them here.
+sed -i "s/SHLIB_VERSION=.*/SHLIB_VERSION=%{soversion}/" VERSION.dat
+./Configure \
+	--prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls ${sslflags} \
+	zlib enable-camellia enable-seed enable-rfc3779 enable-sctp \
+	enable-cms enable-md2 enable-rc5 enable-ktls enable-fips\
+	no-mdc2 no-ec2m no-sm2 no-sm4 enable-buildtest-c++\
+	shared ${sslarch} $RPM_OPT_FLAGS '-DDEVRANDOM="\"/dev/urandom\""'
+
+make %{?_smp_mflags} all
+
+# Clean up the .pc files
+for i in libcrypto.pc libssl.pc openssl.pc ; do
+  sed -i '/^Libs.private:/{s/-L[^ ]* //;s/-Wl[^ ]* //}' $i
+done
+
+%check
+# Verify that what was compiled actually works.
+
+# Hack - either enable SCTP AUTH chunks in kernel or disable sctp for check
+(sysctl net.sctp.addip_enable=1 && sysctl net.sctp.auth_enable=1) || \
+(echo 'Failed to enable SCTP AUTH chunks, disabling SCTP for tests...' &&
+ sed '/"msan" => "default",/a\ \ "sctp" => "default",' configdata.pm > configdata.pm.new && \
+ touch -r configdata.pm configdata.pm.new && \
+ mv -f configdata.pm.new configdata.pm)
+
+OPENSSL_ENABLE_MD5_VERIFY=
+export OPENSSL_ENABLE_MD5_VERIFY
+OPENSSL_ENABLE_SHA1_SIGNATURES=
+export OPENSSL_ENABLE_SHA1_SIGNATURES
+OPENSSL_SYSTEM_CIPHERS_OVERRIDE=xyz_nonexistent_file
+export OPENSSL_SYSTEM_CIPHERS_OVERRIDE
+#run tests itself
+make test HARNESS_JOBS=8
+
+%define __provides_exclude_from %{_libdir}/openssl-%{soversion}
+
+%install
+[ "$RPM_BUILD_ROOT" != "/" ] && rm -rf $RPM_BUILD_ROOT
+# Install OpenSSL.
+install -d $RPM_BUILD_ROOT{%{_bindir},%{_includedir},%{_libdir},%{_libdir}/openssl-%{soversion}}
+
+%{__make} install_sw DESTDIR=%{?buildroot}
+
+rename so.%{soversion} so.%{version} $RPM_BUILD_ROOT%{_libdir}/*.so.%{soversion}
+for lib in $RPM_BUILD_ROOT%{_libdir}/*.so.%{version} ; do
+	chmod 755 ${lib}
+	ln -s -f `basename ${lib}` $RPM_BUILD_ROOT%{_libdir}/`basename ${lib} .%{version}`
+	ln -s -f `basename ${lib}` $RPM_BUILD_ROOT%{_libdir}/`basename ${lib} .%{version}`.%{soversion}
+done
+mv $RPM_BUILD_ROOT%{_bindir}/openssl $RPM_BUILD_ROOT%{_bindir}/%{name}
+
+# Remove static libraries
+for lib in $RPM_BUILD_ROOT%{_libdir}/*.a ; do
+	rm -f ${lib}
+done
+# Remove mans and docs
+#rm -rf $RPM_BUILD_ROOT{%{_mandir},%{_pkgdocdir}}
+
+# Next step of gradual disablement of SSL3.
+# Make SSL3 disappear to newly built dependencies.
+sed -i '/^\#ifndef OPENSSL_NO_SSL_TRACE/i\
+#ifndef OPENSSL_NO_SSL3\
+# define OPENSSL_NO_SSL3\
+#endif' $RPM_BUILD_ROOT/%{_prefix}/include/openssl/opensslconf.h
+
+%files
+%{_bindir}/%{name}
+
+%files libs
+%attr(0755,root,root) %{_libdir}/libcrypto.so.%{version}
+%{_libdir}/libcrypto.so.%{soversion}
+%attr(0755,root,root) %{_libdir}/libssl.so.%{version}
+%{_libdir}/libssl.so.%{soversion}
+%attr(0755,root,root) %{_libdir}/engines-%{soversion}
+
+%files devel
+%{_prefix}/include/openssl
+%{_libdir}/*.so
+%{_libdir}/pkgconfig/*.pc
+
+%ldconfig_scriptlets libs
+
+%changelog

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+if [ ! -z "$USE_DAVIX_WITH_OPENSSL31" ]; then
+    echo "=================== installing davix with openssl 3.1 ============================"
+    rpm -i /tmp/rpms/openssl31-libs-3*.rpm
+    rpm -U --force /tmp/rpms/davix-libs-0*.rpm
+fi
+
 if [ -f /opt/rucio/etc/rucio.cfg ]; then
     echo "rucio.cfg already mounted."
 else


### PR DESCRIPTION
Adapt the current dockerfile to always build openssl3.1 and davix and store the new RPMs ready for installation. This is to avoid having to build two different containers for alma9.

Add an ENV variable switch in the start-daemon.sh script to install these RPMs, if desired, just before running rucio.