### PR TITLE
daemons: allow sha1 on alma9

### DIFF
--- a/daemons/alma9.Dockerfile
+++ b/daemons/alma9.Dockerfile
@@ -44,6 +44,8 @@ RUN python3 -m pip install --no-cache-dir j2cli
 ADD rucio.config.default.cfg /tmp/
 ADD start-daemon.sh /
 
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 RUN mkdir /var/log/rucio
 
 VOLUME /var/log/rucio


### PR DESCRIPTION
Similarly to servers. Was forgotten. It's still used by some CAs.