### PR TITLE
build: prepend-rucio to fs containers

### DIFF
--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -27,7 +27,7 @@ jobs:
           'ssh, push-tagged, push-latest',
           'xrootd, push-tagged, push-latest',
           'xrootd-noauth, push-tagged, push-latest',
-          'fs, rucio-clients:release-#TAG, push-tagged, push-latest'
+          'fs, rucio-clients:release-#TAG, prepend-rucio, push-tagged, push-latest'
         ]
       fail-fast: false
     


### PR DESCRIPTION
In the recent changes related to pushing versioned containers for everything, the `rucio-fs` naming scheme was changed to `fs`, which was not an intentional change. This commit fixes the error.