### PR TITLE
daemons: use openssl 3.1 by default

### DIFF
--- a/daemons/alma9.Dockerfile
+++ b/daemons/alma9.Dockerfile
@@ -68,4 +68,6 @@ COPY --from=rpm_builder /root/rpmbuild/RPMS/x86_64/*.rpm /tmp/rpms/
 VOLUME /var/log/rucio
 VOLUME /opt/rucio/etc
 
+ENV USE_DAVIX_WITH_OPENSSL31=True
+
 ENTRYPOINT ["/start-daemon.sh"]

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -z "$USE_DAVIX_WITH_OPENSSL31" ]; then
+if [ "$USE_DAVIX_WITH_OPENSSL31" = 'True' ]; then
     echo "=================== installing davix with openssl 3.1 ============================"
     rpm -i /tmp/rpms/openssl31-libs-3*.rpm
     rpm -U --force /tmp/rpms/davix-libs-0*.rpm


### PR DESCRIPTION
Can still be disabled by setting the env variable
USE_DAVIX_WITH_OPENSSL31 to anything != 'True'