### PR TITLE
xrootd: relax crypto-policies in the xrootd container

### DIFF
--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -20,6 +20,8 @@ RUN chown -R xrootd:xrootd /etc/grid-security/xrd
 RUN mkdir /rucio
 RUN chown xrootd:xrootd /rucio
 
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 # Server config
 ADD xrdrucio.cfg /etc/xrootd/xrdrucio.cfg
 ADD xrdadler32.sh /usr/local/bin/xrdadler32.sh


### PR DESCRIPTION
xrootd was recently migrated to alma9, but has to be contacted by the centos7-based fts container.