### PR TITLE
fts: use the token test repository. Closes #266

### DIFF
--- a/fts/Dockerfile
+++ b/fts/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 # Install FTS
 RUN yum install -y epel-release.noarch
-RUN curl https://fts-repo.web.cern.ch/fts-repo/fts3-rc-el7.repo > /etc/yum.repos.d/fts3-rc-el7.repo
+ADD fts3-token-test.repo /etc/yum.repos.d/fts3-token-test.repo
 RUN curl https://fts-repo.web.cern.ch/fts-repo/fts3-depend-el7.repo >  /etc/yum.repos.d/fts3-depend-el7.repo
 RUN curl https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo > /etc/yum.repos.d/dmc-el7.repo
 RUN yum upgrade -y && \

--- a/fts/fts3-token-test.repo
+++ b/fts/fts3-token-test.repo
@@ -1,0 +1,6 @@
+[fts3-token-test-el7]
+name=FTS3 Token Test Repository
+baseurl=https://fts-repo.web.cern.ch/fts-repo/testing/FTS-1925_token_project/el7/x86_64/
+gpgcheck=0
+enabled=1
+protect=0


### PR DESCRIPTION
not 100% sure it's enough for tokens, but FTS starts and passes our other tests without issues.