### PR TITLE
servers: allow exposing a separate health-check port

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -120,3 +120,12 @@ Listen {{ RUCIO_METRICS_PORT }}
  WSGIScriptAlias /metrics {{ RUCIO_PYTHON_PATH }}/web/rest/metrics.py process-group=rucio application-group=rucio
 </VirtualHost>
 {% endif %}
+
+{% if RUCIO_HEALTH_CHECK_PORT is defined %}
+Listen {{ RUCIO_HEALTH_CHECK_PORT }}
+<VirtualHost *:{{ RUCIO_HEALTH_CHECK_PORT }} >
+{{ common_virtual_host_config(port=RUCIO_HEALTH_CHECK_PORT, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True') }}
+
+ WSGIScriptAlias /ping {{ RUCIO_PYTHON_PATH }}/web/rest/ping.py process-group=rucio application-group=rucio
+</VirtualHost>
+{% endif %}


### PR DESCRIPTION
This will make integration in kubernetes with proxy protocol enabled much easier. Do exactly the same thing as we do for the prometheus metrics endpoint a couple of lines above.