### PR TITLE
Patching: filter and apply bin and lib patches separately, and fail explicitly if patching fails (fix #238 and #249)

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM almalinux:9 as rpm_builder
     RUN dnf upgrade -y
-    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch
+    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch patchutils
     RUN yum-config-manager --enable crb
     # BUILD and install openssl 3.1
     ADD openssl.spec    /root/rpmbuild/SPECS/openssl.spec

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -37,8 +37,31 @@ then
     echo "Patches found. Trying to apply them"
     for patchfile in /patch/*
     do
-        echo "Apply patch ${patchfile}"
-        patch -p3 -d "$RUCIO_PYTHON_PATH" < $patchfile
+        echo "Applying patch ${patchfile}"
+        
+        bin_patch=$(filterdiff -i '*/bin/*' ${patchfile})
+
+        if [ -n "$bin_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $bin_patch
+            then
+                echo "Patch ${bin_patch} applied."
+            else
+                echo "Patch ${bin_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
+
+        lib_patch=$(filterdiff -i '*/lib/*' ${patchfile})
+
+        if [ -n "$lib_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $lib_patch
+            then
+                echo "Patch ${lib_patch} applied."
+            else
+                echo "Patch ${lib_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
     done
 fi
 

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -35,33 +35,41 @@ fi
 if [ -d "/patch" ]
 then
     echo "Patches found. Trying to apply them"
-    for patchfile in /patch/*
+
+    TMP_PATCH_DIR="$(mktemp -d)"
+    trap 'rm -rf -- "$TMP_PATCH_DIR"' EXIT # Deletes temp dir when script exits
+
+    for patchfile in /patch/*.patch
     do
         echo "Applying patch ${patchfile}"
         
-        bin_patch=$(filterdiff -i '*/bin/*' ${patchfile})
+        tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
+        filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}
 
-        if [ -n "$bin_patch" ]
+        if [ -s ${tmp_bin_file} ]
         then
-            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $bin_patch
+            if patch -p2 -d "/usr/local/bin/" < ${tmp_bin_file}
             then
-                echo "Patch ${bin_patch} applied."
+                echo "Patch ${patchfile}/bin applied."
             else
-                echo "Patch ${bin_patch} could not be applied successfully (exit code $?). Exiting setup."
+                echo "Patch ${patchfile}/bin could not be applied successfully (exit code $?). Exiting setup."
                 exit 1
-            fi            
+            fi
+        fi
 
-        lib_patch=$(filterdiff -i '*/lib/*' ${patchfile})
+        tmp_lib_file="${TMP_PATCH_DIR}/tmp_lib"
+        filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}
 
-        if [ -n "$lib_patch" ]
+        if [ -s ${tmp_lib_file} ]
         then
-            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $lib_patch
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < ${tmp_lib_file}
             then
-                echo "Patch ${lib_patch} applied."
+                echo "Patch ${patchfile}/lib applied."
             else
-                echo "Patch ${lib_patch} could not be applied successfully (exit code $?). Exiting setup."
+                echo "Patch ${patchfile}/lib could not be applied successfully (exit code $?). Exiting setup."
                 exit 1
-            fi            
+            fi
+        fi
     done
 fi
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf install -y epel-release.noarch && \
         python-pip \
         python-mod_wsgi \
         memcached && \
+        patchutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf install -y epel-release.noarch && \
         procps-ng \
         python-pip \
         python-mod_wsgi \
-        memcached && \
+        memcached \
         patchutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -48,8 +48,31 @@ then
     echo "Patches found. Trying to apply them"
     for patchfile in /patch/*
     do
-        echo "Apply patch ${patchfile}"
-        patch -p3 -d "$RUCIO_PYTHON_PATH" < $patchfile
+        echo "Applying patch ${patchfile}"
+        
+        bin_patch=$(filterdiff -i '*/bin/*' ${patchfile})
+
+        if [ -n "$bin_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $bin_patch
+            then
+                echo "Patch ${bin_patch} applied."
+            else
+                echo "Patch ${bin_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
+
+        lib_patch=$(filterdiff -i '*/lib/*' ${patchfile})
+
+        if [ -n "$lib_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $lib_patch
+            then
+                echo "Patch ${lib_patch} applied."
+            else
+                echo "Patch ${lib_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
     done
 fi
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -46,33 +46,41 @@ echo ""
 if [ -d "/patch" ]
 then
     echo "Patches found. Trying to apply them"
-    for patchfile in /patch/*
+
+    TMP_PATCH_DIR="$(mktemp -d)"
+    trap 'rm -rf -- "$TMP_PATCH_DIR"' EXIT # Deletes temp dir when script exits
+
+    for patchfile in /patch/*.patch
     do
         echo "Applying patch ${patchfile}"
         
-        bin_patch=$(filterdiff -i '*/bin/*' ${patchfile})
+        tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
+        filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}
 
-        if [ -n "$bin_patch" ]
+        if [ -s ${tmp_bin_file} ]
         then
-            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $bin_patch
+            if patch -p2 -d "/usr/local/bin/" < ${tmp_bin_file}
             then
-                echo "Patch ${bin_patch} applied."
+                echo "Patch ${patchfile}/bin applied."
             else
-                echo "Patch ${bin_patch} could not be applied successfully (exit code $?). Exiting setup."
+                echo "Patch ${patchfile}/bin could not be applied successfully (exit code $?). Exiting setup."
                 exit 1
-            fi            
+            fi
+        fi
 
-        lib_patch=$(filterdiff -i '*/lib/*' ${patchfile})
+        tmp_lib_file="${TMP_PATCH_DIR}/tmp_lib"
+        filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}
 
-        if [ -n "$lib_patch" ]
+        if [ -s ${tmp_lib_file} ]
         then
-            if patch -p3 -d "$RUCIO_PYTHON_PATH" < $lib_patch
+            if patch -p3 -d "$RUCIO_PYTHON_PATH" < ${tmp_lib_file}
             then
-                echo "Patch ${lib_patch} applied."
+                echo "Patch ${patchfile}/lib applied."
             else
-                echo "Patch ${lib_patch} could not be applied successfully (exit code $?). Exiting setup."
+                echo "Patch ${patchfile}/lib could not be applied successfully (exit code $?). Exiting setup."
                 exit 1
-            fi            
+            fi
+        fi
     done
 fi
 

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update && \
     dnf -y module reset nodejs && \
     dnf -y module enable nodejs:18 && \
     dnf -y module install nodejs:18/common && \
-    dnf -y install httpd mod_ssl python39 python-pip git procps && \
+    dnf -y install httpd mod_ssl python39 python-pip git procps patchutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -16,10 +16,34 @@ then
     echo "Patches found. Trying to apply them"
     for patchfile in /patch/*
     do
-        echo "Apply patch ${patchfile}"
-        patch -p3 -d "$RUCIO_WEBUI_PATH" < $patchfile
+        echo "Applying patch ${patchfile}"
+        
+        bin_patch=$(filterdiff -i '*/bin/*' ${patchfile})
+
+        if [ -n "$bin_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_WEBUI_PATH" < $bin_patch
+            then
+                echo "Patch ${bin_patch} applied."
+            else
+                echo "Patch ${bin_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
+
+        lib_patch=$(filterdiff -i '*/lib/*' ${patchfile})
+
+        if [ -n "$lib_patch" ]
+        then
+            if patch -p3 -d "$RUCIO_WEBUI_PATH" < $lib_patch
+            then
+                echo "Patch ${lib_patch} applied."
+            else
+                echo "Patch ${lib_patch} could not be applied successfully (exit code $?). Exiting setup."
+                exit 1
+            fi            
     done
 fi
+
 
 echo "=================== Starting RUCIO WEBUI ========================"
 npm run start


### PR DESCRIPTION
fixes #238 - explicitly failing container setup when patching fails
fixes #249  - filtering patches by directory in order to apply bin and lib patches separately