### PR TITLE
Change clients to have a login bash as entrypoint

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -41,7 +41,9 @@ WORKDIR /home/user
 # Add the default rucio configuration
 ADD --chown=user:user rucio.default.cfg /opt/user/rucio.default.cfg
 ADD init_rucio.sh /etc/profile.d/rucio_init.sh
+ADD --chown=user;user ./entrypoint.sh /opt/user/entrypoint.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["/opt/user/entrypoint.sh"]
+CMD ["bash"]

--- a/clients/README.md
+++ b/clients/README.md
@@ -56,6 +56,16 @@ After the container is started you can attach to it and start using the rucio co
     docker exec -it rucio-clients /bin/bash
     $ rucio ping
 
+or just run a single command:
+
+    docker exec -it rucio-clients rucio whoami
+
+You can also run commands directly:
+
+    docker run --rm -it \
+        [... config options like above ] \
+        rucio/rucio-clients rucio whoami
+
 ## `RUCIO_CFG` configuration parameters:
 
 Environment variables can be used to set values for the auto-generated rucio.cfg. The names are derived from the actual names in the configuration file.

--- a/clients/entrypoint.sh
+++ b/clients/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -l
+exec "$@"


### PR DESCRIPTION
This makes it possible to directly run a command in the docker image like this:

```
docker run [...] -v rucio-clients rucio download test:test.dat
```

`-l` is necessary to have bash load the startup script in `/etc/profile.d/` which sets up the rucio config.

Alternatively, that code could also be integrated into the entry point.