### PR TITLE
xrootd & webdav: install the headless qbittorrent package

### DIFF
--- a/webdav/Dockerfile
+++ b/webdav/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
       libapache2-mod-auth-openidc \
       libapache2-mod-oauth2 \
       gridsite \
+      qbittorrent-nox \
     ; \
     apt-get clean
 

--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf install -y epel-release.noarch http://linuxsoft.cern.ch/wlcg/centos7/x86
     dnf update -y && \
     dnf upgrade -y && \
     dnf --disablerepo="*" --enablerepo="carepo" -y install 'ca*' && \
-    dnf install -y xrootd xrootd-client xrootd-scitokens && \
+    dnf install -y xrootd xrootd-client xrootd-scitokens qbittorrent-nox && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
In preparation for the feature in rucio which introduces the torrent transfertool