### PR TITLE
Install `patchutils` as part of the later image in the Dockerfile

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM almalinux:9 as rpm_builder
     RUN dnf upgrade -y
-    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch patchutils
+    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch
     RUN yum-config-manager --enable crb
     # BUILD and install openssl 3.1
     ADD openssl.spec    /root/rpmbuild/SPECS/openssl.spec
@@ -44,6 +44,7 @@ RUN dnf install -y epel-release.noarch && \
         sendmail \
         sendmail-cf \
         memcached \
+        patchutils \
         xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -44,7 +44,11 @@ then
         echo "Applying patch ${patchfile}"
         
         tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
-        filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}
+        
+        if ! filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}; then
+            echo "Error while filtering patch ${patchfile}/bin. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_bin_file} ]
         then
@@ -58,7 +62,11 @@ then
         fi
 
         tmp_lib_file="${TMP_PATCH_DIR}/tmp_lib"
-        filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}
+
+        if ! filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}; then
+            echo "Error while filtering patch ${patchfile}/lib. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_lib_file} ]
         then

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -55,7 +55,11 @@ then
         echo "Applying patch ${patchfile}"
         
         tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
-        filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}
+
+        if ! filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}; then
+            echo "Error while filtering patch ${patchfile}/bin. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_bin_file} ]
         then
@@ -69,7 +73,11 @@ then
         fi
 
         tmp_lib_file="${TMP_PATCH_DIR}/tmp_lib"
-        filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}
+
+        if ! filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}; then
+            echo "Error while filtering patch ${patchfile}/lib. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_lib_file} ]
         then

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -23,7 +23,11 @@ then
         echo "Applying patch ${patchfile}"
         
         tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
-        filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}
+
+        if ! filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}; then
+            echo "Error while filtering patch ${patchfile}/bin. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_bin_file} ]
         then
@@ -37,7 +41,11 @@ then
         fi
 
         tmp_lib_file="${TMP_PATCH_DIR}/tmp_lib"
-        filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}
+
+        if ! filterdiff -i '*/lib/*' "${patchfile}" > ${tmp_lib_file}; then
+            echo "Error while filtering patch ${patchfile}/lib. Exiting setup."
+            exit 1
+        fi
 
         if [ -s ${tmp_lib_file} ]
         then


### PR DESCRIPTION
Beforehand, `patchutils` was being installed as part of the `rpm_builder` image, resulting in `filterdiff` not being found in the final base image - fixing this in this PR

See https://stackoverflow.com/questions/33322103/multiple-froms-what-it-means for more information