### PR TITLE
rucio-ui: use http is ssl is disabled.

### DIFF
--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -37,6 +37,7 @@ CacheRoot /tmp
  ServerAdmin rucio-admin@cern.ch
 {% endif %}
 
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
  SSLEngine on
  SSLCertificateFile /etc/grid-security/hostcert.pem
  SSLCertificateKeyFile /etc/grid-security/hostkey.pem
@@ -54,7 +55,6 @@ CacheRoot /tmp
  SSLOptions +StdEnvVars
 {% endif %}
  SSLProxyEngine On
-
 {% if RUCIO_SSL_PROTOCOL is defined %}
  #AB: SSLv3 disable
  SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
@@ -63,6 +63,8 @@ CacheRoot /tmp
 {% endif %}
  #AB: for Security
  SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
+
 {% if RUCIO_LOG_LEVEL is defined %}
  LogLevel {{ RUCIO_LOG_LEVEL }}
 {% else %}


### PR DESCRIPTION
The error was spotted when I tried to install the rucio-ui helm charts with `.Values.service.useSSL = False`. The container failed to start as it was string to configure the SSL module.

This PR fixes the issue by only configuring the SSL module when the environment variable `RUCIO_ENABLE_SSL` has been explicitly set to true.