### PR TITLE
Rucio UI: Fix rendering issue, update Dockerfile and Apache config

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -46,9 +46,12 @@ ADD 00-mpm.conf.j2 /tmp
 ADD docker-entrypoint.sh /
 RUN rm /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.d/userdir.conf /etc/httpd/conf.d/ssl.conf
 
+RUN update-crypto-policies --set DEFAULT:SHA1
+
 VOLUME /var/log/httpd
 VOLUME /opt/rucio/etc
 
+EXPOSE 80
 EXPOSE 443
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/ui/README.md
+++ b/ui/README.md
@@ -59,6 +59,9 @@ Same as `RUCIO_PROXY_SCHEME` but for the authentication server.
 
 If you are using SSL and want use `SSLCACertificatePath` and `SSLCARevocationPath` you can do so by specifying the path in this variable.
 
+### `RUCIO_CA_FILE`
+If you are using SSL and do not want to hash the CA certificates you can specify the path to the single CA file that contains all of the required certificates in this variable. It sets the `SSLCACertificateFile`  and `SSLCARevocationFile` directives in the apache config.
+
 ### `RUCIO_ENABLE_LOGS`
 
 By default the log output of the web server is written to stdout and stderr. If you set this variable to `True` the output will be written to `access_log` and `error_log` under `/var/log/httpd`.

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -32,4 +32,6 @@ echo "=================== /etc/httpd/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""
 
+pkill httpd || :
+sleep 2
 exec httpd -D FOREGROUND

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -2,7 +2,9 @@ LoadModule ssl_module /usr/lib64/httpd/modules/mod_ssl.so
 LoadModule unique_id_module modules/mod_unique_id.so
 LoadModule wsgi_module /usr/lib64/httpd/modules/mod_wsgi.so
 
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
 Listen 443
+{% endif %}
 Listen 80
 
 Header set X-Rucio-Host "%{HTTP_HOST}e"
@@ -20,49 +22,14 @@ LoadModule cache_disk_module modules/mod_cache_disk.so
 CacheEnable disk /
 CacheRoot /tmp
 
+{% macro common_virtual_host_config() %}
 {% if RUCIO_HOSTNAME is defined %}
-<VirtualHost *:80>
  ServerName {{ RUCIO_HOSTNAME }}:80
- Redirect / https://{{ RUCIO_HOSTNAME }}/
-</VirtualHost>
-
-<VirtualHost *:443>
- ServerName {{ RUCIO_HOSTNAME }}:443
-{% else %}
-<VirtualHost *:443>
 {% endif %}
 {% if RUCIO_SERVER_ADMIN is defined %}
  ServerAdmin {{ RUCIO_SERVER_ADMIN }}
 {% else %}
  ServerAdmin rucio-admin@cern.ch
-{% endif %}
-
-{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
- SSLEngine on
- SSLCertificateFile /etc/grid-security/hostcert.pem
- SSLCertificateKeyFile /etc/grid-security/hostkey.pem
-{% if RUCIO_CA_PATH is defined %}
- SSLCACertificatePath {{ RUCIO_CA_PATH }}
- SSLCARevocationPath {{ RUCIO_CA_PATH }}
-{% else %}
- SSLCACertificateFile /etc/grid-security/ca.pem
-{% endif %}
- SSLVerifyClient optional_no_ca
- SSLVerifyDepth 10
-{% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
- SSLOptions +StdEnvVars +LegacyDNStringFormat
-{% else %}
- SSLOptions +StdEnvVars
-{% endif %}
- SSLProxyEngine On
-{% if RUCIO_SSL_PROTOCOL is defined %}
- #AB: SSLv3 disable
- SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
-{% else %}
- SSLProtocol              +TLSv1.2
-{% endif %}
- #AB: for Security
- SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
 {% endif %}
 
 {% if RUCIO_LOG_LEVEL is defined %}
@@ -72,13 +39,8 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_ENABLE_LOGS|default('False') == 'True' %}
-{% if RUCIO_HTTPD_LOG_DIR is defined %}
- CustomLog {{RUCIO_HTTPD_LOG_DIR}}/access_log combinedrucio
- ErrorLog {{RUCIO_HTTPD_LOG_DIR}}/error_log
-{% else %}
- CustomLog logs/access_log combinedrucio
- ErrorLog logs/error_log
-{% endif %}
+ CustomLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/access_log combinedrucio
+ ErrorLog {{RUCIO_HTTPD_LOG_DIR | default('logs') }}/error_log
 {% else %}
  CustomLog /dev/stdout combinedrucio
  ErrorLog /dev/stderr
@@ -100,4 +62,54 @@ CacheRoot /tmp
   ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
   ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
 {% endif %}
+{% endmacro %}
+
+<VirtualHost *:80>
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+ {% if RUCIO_HOSTNAME is defined %}
+ Redirect / https://{{ RUCIO_HOSTNAME }}/
+ {% else %}
+ Redirect / https://localhost/
+ {% endif %}
+{% else %}
+ {{ common_virtual_host_config()}}
+ {% endif%}
 </VirtualHost>
+
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+<VirtualHost *:443>
+{{ common_virtual_host_config()}}
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+ SSLEngine on
+ SSLCertificateFile /etc/grid-security/hostcert.pem
+ SSLCertificateKeyFile /etc/grid-security/hostkey.pem
+{% if RUCIO_CA_PATH is defined %}
+ SSLCACertificatePath {{ RUCIO_CA_PATH }}
+ SSLCARevocationPath {{ RUCIO_CA_PATH }}
+{% elif RUCIO_CA_FILE is defined %}
+ SSLCACertificateFile {{ RUCIO_CA_FILE }}
+ SSLCARevocationFile {{ RUCIO_CA_FILE }}
+{% else %}
+ SSLCACertificateFile /etc/grid-security/ca.pem
+ SSLCARevocationFile /etc/grid-security/ca.pem
+{% endif %}
+ SSLVerifyClient optional_no_ca
+ SSLVerifyDepth 10
+{% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
+ SSLOptions +StdEnvVars +LegacyDNStringFormat
+{% else %}
+ SSLOptions +StdEnvVars
+{% endif %}
+ SSLProxyEngine On
+{% if RUCIO_SSL_PROTOCOL is defined %}
+ #AB: SSLv3 disable
+ SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
+{% else %}
+ SSLProtocol              +TLSv1.2
+{% endif %}
+ #AB: for Security
+ SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
+{% endif %}
+</VirtualHost>
+{% endif %}
+

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -9,6 +9,22 @@ Listen 80
 
 Header set X-Rucio-Host "%{HTTP_HOST}e"
 RequestHeader add X-Rucio-RequestId "%{UNIQUE_ID}e"
+Header set Referrer-Policy "no-referrer"
+Header always set Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'"
+Header always set X-Frame-Options "SAMEORIGIN"
+Header always set X-XSS-Protection "1; mode=block"
+Header always set X-Content-Type-Options "nosniff"
+
+{% if RUCIO_ENABLE_SSL|default('False') == 'True' %}
+{% if RUCIO_SSL_PROTOCOL is defined %}
+ #AB: SSLv3 disable
+ SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
+{% else %}
+ SSLProtocol              all -SSLv3 -TLSv1 -TLSv1.1
+{% endif %}
+SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder     off
+{% endif %}
 
 {% if RUCIO_LOG_FORMAT is defined %}
 LogFormat "{{ RUCIO_LOG_FORMAT }}" combinedrucio
@@ -55,12 +71,12 @@ CacheRoot /tmp
 {% endif %}
 
 {% if RUCIO_PROXY is defined %}
-  ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
-  ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+ ProxyPass /proxy             {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
+ ProxyPassReverse /proxy      {{ RUCIO_PROXY_SCHEME | default('https') }}://{{ RUCIO_PROXY }}
 {% endif %}
 {% if RUCIO_AUTH_PROXY is defined %}
-  ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
-  ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+ ProxyPass /authproxy             {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
+ ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
 {% endif %}
 {% endmacro %}
 
@@ -93,7 +109,7 @@ CacheRoot /tmp
  SSLCACertificateFile /etc/grid-security/ca.pem
  SSLCARevocationFile /etc/grid-security/ca.pem
 {% endif %}
- SSLVerifyClient optional_no_ca
+ SSLVerifyClient optional
  SSLVerifyDepth 10
 {% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
  SSLOptions +StdEnvVars +LegacyDNStringFormat
@@ -101,14 +117,6 @@ CacheRoot /tmp
  SSLOptions +StdEnvVars
 {% endif %}
  SSLProxyEngine On
-{% if RUCIO_SSL_PROTOCOL is defined %}
- #AB: SSLv3 disable
- SSLProtocol              {{ RUCIO_SSL_PROTOCOL }}
-{% else %}
- SSLProtocol              +TLSv1.2
-{% endif %}
- #AB: for Security
- SSLCipherSuite           HIGH:!CAMELLIA:!ADH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!3DES
 {% endif %}
 </VirtualHost>
 {% endif %}


### PR DESCRIPTION
The way the final `rucio.conf` was rendered from the Jinja template, lead to scenarios where configuration would not be correct and the UI homepage would look like
<img width="427" alt="image" src="https://github.com/rucio/containers/assets/5906242/d687789b-0d76-46bc-abf2-6c513bda195f">

I have cleaned up and re-organized the template, so it renders coherently into a valid apache config

<img width="1107" alt="image" src="https://github.com/rucio/containers/assets/5906242/587f2c45-2f87-4724-8b06-e81ffef9f35f">
