### PR TITLE
daemons/server: Add Grid CAs to the system trust

### DIFF
--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -81,6 +81,12 @@ then
     done
 fi
 
+if [ -d /etc/grid-security/certificates ]; then
+    echo 'Adding Grid CAs to the system trust.'
+    cp -v /etc/grid-security/certificates/*.pem /etc/pki/ca-trust/source/anchors/
+    update-ca-trust extract
+fi
+
 echo "starting daemon with: $RUCIO_DAEMON $RUCIO_DAEMON_ARGS"
 echo ""
 

--- a/server/docker-entrypoint.sh
+++ b/server/docker-entrypoint.sh
@@ -92,6 +92,12 @@ then
     done
 fi
 
+if [ -d /etc/grid-security/certificates ]; then
+    echo 'Adding Grid CAs to the system trust.'
+    cp -v /etc/grid-security/certificates/*.pem /etc/pki/ca-trust/source/anchors/
+    update-ca-trust extract
+fi
+
 pkill httpd || :
 sleep 2
 exec httpd -D FOREGROUND


### PR DESCRIPTION
This is a prerequisite for https://github.com/rucio/rucio/issues/6632 and https://github.com/rucio/rucio/issues/6633.

The origin of the /etc/grid-security directory appears to be Globus. GFAL uses it transparently, but all other native system utilities and libraries do not.

This commits adds the Grid CAs to the system trust at the time the container starts, when applicable.  This will be important for the Rucio components that:

  * Connect directly to the RSEs (Automatix, Dark Reaper, Reaper)
  * Communicate with FTS (Cleaner, Poller, Submitter, and the Rucio servers)

The /etc/grid-security directory does not exist by default; it has to be populated externally and mounted in the container with extraHostPathMounts.