### PR TITLE
Fix build of `ssh` and `fs` containers

### DIFF
--- a/fs/Dockerfile
+++ b/fs/Dockerfile
@@ -2,9 +2,7 @@ ARG TAG
 FROM rucio/rucio-clients:release-$TAG
 
 USER root
-RUN yum install -y git cmake3 libcurl-devel fuse-devel
-RUN yum install -y centos-release-scl-rh
-RUN yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++
+RUN dnf install -y git cmake3 libcurl-devel fuse-devel tree
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:/opt/rh/devtoolset-9/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -15,14 +13,12 @@ ARG CACHEBUST=12
 WORKDIR /opt
 RUN git clone --recursive https://github.com/rucio/fuse-posix.git
 WORKDIR /opt/fuse-posix
-RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake 
 RUN /bin/bash ./build.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 RUN pip3 install argcomplete
 RUN /etc/profile.d/rucio_init.sh
 
-RUN yum install -y tree
 RUN mkdir /ruciofs
 RUN mkdir /ruciofs-cache
 ENV RUCIOFS_SETTINGS_FILES_ROOT /ruciofs-settings

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install -U dumb-init
 
 # Server config


### PR DESCRIPTION
## SSH container
- Created the symlink : `/usr/bin/python3` -> `/usr/bin/python`

## FS container
- Removed installation of `centos-release-scl` and build tools that are already present in alma9
- switched to `dnf` over `yum`
