### PR TITLE
SSH: Remove deprecated UsePrivilegeSeparation option; #311

### DIFF
--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -9,8 +9,6 @@ HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
 
 # Logging
 SyslogFacility AUTH


### PR DESCRIPTION
This was deprecated in OpenSSH 7.5: https://www.openssh.com/txt/release-7.5

>  * This release deprecates the sshd_config UsePrivilegeSeparation option, thereby making privilege separation mandatory. Privilege separation has been on by default for almost 15 years and sandboxing has been on by default for almost the last five.