### PR TITLE
dev, ssh: update rclone to latest

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -44,16 +44,18 @@ RUN dnf -y install yum-utils epel-release.noarch && \
         python3-devel \
         python3-mod_wsgi \
         python3-m2crypto \
-        rclone \
         rsync \
+        unzip \
         vim \
         voms-clients-java \
         which \
         xmlsec1-devel \
         xmlsec1-openssl-devel \
         xrootd-client && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+RUN curl https://rclone.org/install.sh | bash
 
 ARG GIT_CLONE_ARGS="--depth 1 https://github.com/rucio/rucio.git"
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -7,12 +7,13 @@ RUN dnf install -y epel-release.noarch && \
         openssh-server \
         openssh-clients \
         python-pip \
-        rclone \
         rsync \
-        sudo && \
+        sudo \
+        unzip && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+RUN curl https://rclone.org/install.sh | bash
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install -U dumb-init
 


### PR DESCRIPTION
The outdated `rclone` versions (1.57-DEV) in the `dev` and `ssh` container do not work with the openssl versions available in those containers. This is causing the rclone integration tests to fail https://github.com/rucio/rucio/issues/6763 

This PR bumps the `rclone` version to the latest available version. I recreated the failing integration tests, applied this patch which made the tests pass.

p.s. this will require a release ( or at least pushing the updated containers to Docker Hub), so that the integration tests can use the updated containers

