### PR TITLE
FTS-CRON: add COMPASS voms information

### DIFF
--- a/fts-cron/vomses/vo.compass.cern.ch-voms-compass-auth.cern.ch
+++ b/fts-cron/vomses/vo.compass.cern.ch-voms-compass-auth.cern.ch
@@ -1,0 +1,1 @@
+"vo.compass.cern.ch" "voms-compass-auth.cern.ch" "443" "/DC=ch/DC=cern/OU=computers/CN=compass-auth.cern.ch" "vo.compass.cern.ch" "24"


### PR DESCRIPTION
COMPASS is a CERN experiment that will use RUCIO, as such, the COMPASS VO needs to be configured, therefore this PR.