### PR TITLE
FTS: Pin FTS to latest version used in Rucio 34.2.0

### DIFF
--- a/fts/Dockerfile
+++ b/fts/Dockerfile
@@ -7,7 +7,17 @@ RUN curl https://fts-repo.web.cern.ch/fts-repo/fts3-depend-el7.repo >  /etc/yum.
 RUN curl https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo > /etc/yum.repos.d/dmc-el7.repo
 RUN yum upgrade -y && \
     yum install -y centos-release-scl
-RUN yum install -y mysql multitail gfal2-plugin* fts-server fts-rest-server fts-monitoring fts-mysql fts-msg zeromq
+RUN yum install -y \
+    mysql \
+    multitail \
+    gfal2-plugin* \ 
+    fts-libs-3.14.0-r2404100902git47e773b.el7.cern.x86_64 \
+    fts-server-3.14.0-r2404100902git47e773b.el7.cern.x86_64 \
+    fts-rest-server-3.14.0-r2404100848gitb7554d5.el7.cern.noarch \ 
+    fts-monitoring \ 
+    fts-mysql-3.14.0-r2404100902git47e773b.el7.cern.x86_64 \ 
+    fts-msg-3.14.0-r2404100902git47e773b.el7.cern.x86_64 \ 
+    zeromq
 RUN yum clean all
 
 # Database configuration for FTS server


### PR DESCRIPTION
3.14.0-r2404100902git47e773b is the latest FTS version that was used in Rucio 34.2.0, which was released on 2024-04-16.

This change is to address this issue:
https://github.com/rucio/rucio/issues/6774.

The `fts-libs` is added as direct dependency (specifically, `fts-libs-3.14.0-r2404100902git47e773b.el7.cern.x86_64`) because it is required by `fts-server-3.14.0-r2404100902git47e773b.el7.cern.x86_64`, and for some reason the dependency resolution errors out if it tries to find the correct `fts-libs` version when it's not specified.

fts-monitoring has no specified versions in the fts3-token-test repo, so it's left unpinned to latest. (I'm not even sure if this package actually gets installed, as there's this log in the Docker build logs: No package fts-monitoring available.")