### PR TITLE
Dependencies: Temporarily accept either requirements.txt and requirements.dev.txt in the dev container

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -74,7 +74,9 @@ RUN mkdir -p \
 
 RUN python3 -m pip install --no-cache --upgrade pip && \
     python3 -m pip install --no-cache --upgrade setuptools wheel && \
-    if [ -r /tmp/rucio/requirements/requirements.dev.txt ]; then \
+    if [ -r /tmp/rucio/requirements.txt ]; then \
+        python3 -m pip install --no-cache --upgrade -r /tmp/rucio/requirements.txt ; \
+    elif [ -r /tmp/rucio/requirements/requirements.dev.txt ]; then \
         python3 -m pip install --no-cache --upgrade -r /tmp/rucio/requirements/requirements.dev.txt ; \
     else \
         python3 -m pip install --no-cache --upgrade -r /tmp/rucio/etc/pip-requires-client \


### PR DESCRIPTION
As part of https://github.com/rucio/rucio/issues/6750, we split `requirements.txt` in `rucio/rucio` into separate requirements files, depending on the application. We are keeping this change unreleased until the next major Rucio release.

Until then, integration tests on `rucio/rucio:master` will use the new `requirements.dev.txt` file, while the ones on `rucio/rucio:release-34` will use the old `requirements.txt` file.

This commit is a temporary fix which will be removed after the next major release. This issue will remain open until then: https://github.com/rucio/containers/issues/323