### PR TITLE
ui: add option to configure `RemoteIPProxyProtocol` directive

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -100,6 +100,14 @@ This variable can be used to add an additional `ProxyPass` and corresponding `Pr
     ProxyPassReverse /foo http://bar
 ```
 
+### `RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED`
+
+This variable can be used to enable the `ProxyProtocol` module in the apache config. The default is `Off`. It sets the `RemoteIPProxyProtocol` directive in the apache config.
+
+### `RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS`
+
+This variable can be used to set the `RemoteIPProxyProtocolExceptions` directive in the apache config. If the `RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED` is set to `True`, then the supplied values are excluded from proxy protocol processing.
+
 ## `RUCIO_CFG` configuration parameters:
 
 Environment variables can be used to set values for the auto-generated rucio.cfg. The names are derived from the actual names in the configuration file prefixed by `RUCIO_CFG`, e.g., the `default` value in the `database` section becomes `RUCIO_CFG_DATABASE_DEFAULT`.

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -82,6 +82,10 @@ CacheRoot /tmp
  ProxyPass {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF}}
  ProxyPassReverse {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF }}
 {% endif %}
+{% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
+ RemoteIPProxyProtocol On
+ RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}
+{% endif %}
 {% endmacro %}
 
 <VirtualHost *:80>


### PR DESCRIPTION
In deployment scenarios where the Rucio UI sits behind a proxy ( a loadbalancer or another reverse proxy), the client information must be handled by the UI container's httpd process.

This PR configures the `RemoteIPProxyProtocol` directive to enable the UI do to so