### PR TITLE
WIP: Update fts image to use alma9

### DIFF
--- a/fts/Dockerfile
+++ b/fts/Dockerfile
@@ -1,37 +1,37 @@
-FROM centos:7
+FROM almalinux:9
+
+# Enable EPEL
+RUN dnf install -y yum-utils \
+  && dnf config-manager --set-enabled crb \
+  && dnf install -y epel-release
+
 
 # Install FTS
-RUN yum install -y epel-release.noarch
-ADD fts3-testing.repo /etc/yum.repos.d/fts3-testing.repo
-RUN curl https://fts-repo.web.cern.ch/fts-repo/fts3-depend-el7.repo >  /etc/yum.repos.d/fts3-depend-el7.repo
-RUN curl https://dmc-repo.web.cern.ch/dmc-repo/dmc-el7.repo > /etc/yum.repos.d/dmc-el7.repo
-RUN yum upgrade -y && \
-    yum install -y centos-release-scl
-RUN yum install -y \
-    mysql \
-    multitail \
-    gfal2-plugin* \ 
-    fts-libs-3.13.0-r2405271344gitc6d02cc.el7.cern.x86_64 \
-    fts-server-3.13.0-r2405271344gitc6d02cc.el7.cern.x86_64 \
-    fts-rest-server-3.13.0-r2405271058git798429f.el7.cern.noarch \ 
-    fts-monitoring \ 
-    fts-mysql-3.13.0-r2405271344gitc6d02cc.el7.cern.x86_64 \ 
-    fts-msg-3.13.0-r2405271344gitc6d02cc.el7.cern.x86_64 \ 
-    zeromq
-RUN yum clean all
+RUN curl -sSfL -o /etc/yum.repos.d/fts3.repo https://fts-repo.web.cern.ch/fts-repo/fts3-el9.repo \
+  && curl -sSfL -o /etc/yum.repos.d/fts3-depend.repo https://fts-repo.web.cern.ch/fts-repo/fts3-depend.repo
 
-# Database configuration for FTS server
+
+RUN  dnf install -y \
+  fts-server fts-mysql fts-rest-client fts-rest-server fts-monitoring \
+  fts-server-selinux fts-rest-server-selinux fts-monitoring-selinux \
+  fts-msg \
+  mysql \
+  multitail
+  
+
 COPY fts3config /etc/fts3/fts3config
 RUN chmod +x /usr/share/fts/fts-database-upgrade.py
 
 # Configuration for FTSREST and FTSMON
 COPY fts3rest.conf /etc/httpd/conf.d/fts3rest.conf
 COPY fts3restconfig /etc/fts3/fts3restconfig
-RUN echo "" > /etc/httpd/conf.d/ssl.conf &&\
-    echo "" > /etc/httpd/conf.d/autoindex.conf &&\
-    echo "" > /etc/httpd/conf.d/userdir.conf &&\
-    echo "" > /etc/httpd/conf.d/welcome.conf &&\
-    echo "" > /etc/httpd/conf.d/zgridsite.conf
+RUN \
+     echo "" > /etc/httpd/conf.d/ssl.conf \
+  && echo "" > /etc/httpd/conf.d/autoindex.conf \
+  && echo "" > /etc/httpd/conf.d/userdir.conf \
+  && echo "" > /etc/httpd/conf.d/welcome.conf \
+  && echo "" > /etc/httpd/conf.d/zgridsite.conf \
+  && mkdir -p /etc/grid-security/certificates
 
 # FTS monitoring ActiveMQ configuration
 COPY fts-msg-monitoring.conf /etc/fts3/fts-msg-monitoring.conf

--- a/fts/docker-compose.yml
+++ b/fts/docker-compose.yml
@@ -1,17 +1,18 @@
-version: "2"
 services:
   fts:
-    image: rucio/fts
+    build: .
     hostname: fts
     ports:
       - "8446:8446"
       - "8449:8449"
-    links:
-      - ftsdb:ftsdb
     depends_on:
       - ftsdb
+    networks:
+      - fts
+
+
   ftsdb:
-    image: mysql:5
+    image: mysql:8
     hostname: ftsdb
     environment:
       - MYSQL_USER=fts
@@ -20,3 +21,13 @@ services:
       - MYSQL_DATABASE=fts
     ports:
       - "3306:3306"
+    networks:
+      - fts
+    volumes:
+      - ftsdb-data:/var/lib/mysql
+
+networks:
+  fts:
+
+volumes:
+  ftsdb-data:

--- a/fts/docker-entrypoint.sh
+++ b/fts/docker-entrypoint.sh
@@ -1,20 +1,15 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 # wait for MySQL readiness
 /usr/local/bin/wait-for-it.sh -h ftsdb -p 3306 -t 3600
 
 # initialise / upgrade the database
-mysql -h ftsdb -u fts --password=fts fts < $(ls /usr/share/fts-mysql/fts-schema* | sort -t '-' -k '4n' | tail -n 1)
-# TODO: go back to using this script once the fixed it and bundled with the new fts version:
-# /usr/share/fts/fts-database-upgrade.py -y
-
-# fix Apache configuration
-/usr/bin/sed -i 's/Listen 80/#Listen 80/g' /etc/httpd/conf/httpd.conf
-cp /opt/rh/httpd24/root/usr/lib64/httpd/modules/mod_rh-python36-wsgi.so /lib64/httpd/modules
-cp /opt/rh/httpd24/root/etc/httpd/conf.modules.d/10-rh-python36-wsgi.conf /etc/httpd/conf.modules.d
+/usr/share/fts/fts-database-upgrade.py -y
 
 # startup the FTS services
 /usr/sbin/fts_server               # main FTS server daemonizes
 /usr/sbin/fts_msg_bulk             # daemon to send messages to activemq
-/usr/sbin/fts_bringonline          # daemon to handle staging requests
-/usr/sbin/httpd -DFOREGROUND       # FTS REST frontend & FTSMON
+/usr/sbin/fts_qos                  # daemon to handle staging requests
+exec /usr/sbin/httpd -DFOREGROUND       # FTS REST frontend & FTSMON

--- a/fts/fts3-testing.repo
+++ b/fts/fts3-testing.repo
@@ -1,6 +1,0 @@
-[fts3-testing-el7]
-name=FTS3 Test Repository
-baseurl=https://fts-repo.web.cern.ch/fts-repo/testing/el7/x86_64/
-gpgcheck=0
-enabled=1
-protect=0


### PR DESCRIPTION
Today I was following the new installation instructions and trying to setup a docker container for fts on alma 9.

Here is how far I came.

This is not tested yet in any meaningful way, happy to hear what you'd like to see for testing.


Side note: the docker-compose file is not really helpful, it doesn't actually start as all the certificates are missing and are required for fts / httpd to actually startup