### PR TITLE
ui: add `RUCIO_HTTPD_ADDITIONAL_REDIRECTS` environment variable

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -100,6 +100,21 @@ This variable can be used to add an additional `ProxyPass` and corresponding `Pr
     ProxyPassReverse /foo http://bar
 ```
 
+### `RUCIO_HTTPD_ADDITIONAL_REDIRECTS`
+
+This variable can be used to add an additional `Redirect` in the apache config. The value should be a string with the format `/{path} {url}`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
+
+```bash
+    Redirect /foo http://bar
+```
+
+You can add multiple refirects if you specify the value of the environment variable in the following format: `/{path1} {url1}, /{path2} {url2}, ...`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar, /baz http://qux"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
+
+```bash
+    Redirect /foo http://bar
+    Redirect /baz http://qux
+```
+
 ### `RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED`
 
 This variable can be used to enable the `ProxyProtocol` module in the apache config. The default is `Off`. It sets the `RemoteIPProxyProtocol` directive in the apache config.

--- a/ui/README.md
+++ b/ui/README.md
@@ -100,6 +100,15 @@ This variable can be used to add an additional `ProxyPass` and corresponding `Pr
     ProxyPassReverse /foo http://bar
 ```
 
+You can also specify multiple proxies if you specify the value of the environment variable in the following format: `/{path1} {url1}, /{path2} {url2}, ...`. For example `RUCIO_HTTPD_ADDITIONAL_PROXY_CONF="/foo http://bar, /baz http://qux"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
+
+```bash
+    ProxyPass /foo http://bar
+    ProxyPassReverse /foo http://bar
+    ProxyPass /baz http://qux
+    ProxyPassReverse /baz http://qux
+```
+
 ### `RUCIO_HTTPD_ADDITIONAL_REDIRECTS`
 
 This variable can be used to add an additional `Redirect` in the apache config. The value should be a string with the format `/{path} {url}`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
@@ -108,7 +117,7 @@ This variable can be used to add an additional `Redirect` in the apache config. 
     Redirect /foo http://bar
 ```
 
-You can add multiple refirects if you specify the value of the environment variable in the following format: `/{path1} {url1}, /{path2} {url2}, ...`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar, /baz http://qux"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
+You can add multiple redirects if you specify the value of the environment variable in the following format: `/{path1} {url1}, /{path2} {url2}, ...`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar, /baz http://qux"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:
 
 ```bash
     Redirect /foo http://bar

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -79,18 +79,19 @@ CacheRoot /tmp
  ProxyPassReverse /authproxy      {{ RUCIO_AUTH_PROXY_SCHEME | default('https') }}://{{ RUCIO_AUTH_PROXY }}
 {% endif %}
 {% if RUCIO_HTTPD_ADDITIONAL_PROXY_CONF is defined %}
- ProxyPass {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF}}
- ProxyPassReverse {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF }}
+{% for proxy in RUCIO_HTTPD_ADDITIONAL_PROXY_CONF.split(",") %}
+ ProxyPass {{ proxy|trim }}
+ ProxyPassReverse {{ proxy|trim }}
+{% endfor %}
+{% endif %}
+{% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
+ RemoteIPProxyProtocol On
+ RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}
 {% endif %}
 {% if RUCIO_HTTPD_ADDITIONAL_REDIRECTS is defined %}
 {% for redirect in RUCIO_HTTPD_ADDITIONAL_REDIRECTS.split(',') %}
  Redirect {{ redirect|trim }}
 {% endfor %}
- ProxyPassReverse {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF }}
-{% endif %}
-{% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
- RemoteIPProxyProtocol On
- RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}
 {% endif %}
 {% endmacro %}
 

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -82,6 +82,12 @@ CacheRoot /tmp
  ProxyPass {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF}}
  ProxyPassReverse {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF }}
 {% endif %}
+{% if RUCIO_HTTPD_ADDITIONAL_REDIRECTS is defined %}
+{% for redirect in RUCIO_HTTPD_ADDITIONAL_REDIRECTS.split(',') %}
+ Redirect {{ redirect|trim }}
+{% endfor %}
+ ProxyPassReverse {{ RUCIO_HTTPD_ADDITIONAL_PROXY_CONF }}
+{% endif %}
 {% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
  RemoteIPProxyProtocol On
  RemoteIPProxyProtocolExceptions 127.0.0.1 ::1 {{ RUCIO_HTTPD_PROXY_PROTOCOL_EXCEPTIONS | default('') }}


### PR DESCRIPTION
This variable can be used to add an additional `Redirect` in the apache config. The value should be a string with the format `/{path} {url}`.

For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:

```bash
    Redirect /foo http://bar
```

You can add multiple refirects if you specify the value of the environment variable in the following format: `/{path1} {url1}, /{path2} {url2}, ...`. For example `RUCIO_HTTPD_ADDITIONAL_REDIRECTS="/foo http://bar, /baz http://qux"` will add the following lines to the apache config located at `/etc/httpd/conf.d/rucio.conf` inside the container:

```bash
    Redirect /foo http://bar
    Redirect /baz http://qux
```