### PR TITLE
ui, webui: install patch, patchutils

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -26,6 +26,8 @@ RUN dnf install -y epel-release.noarch && \
         python3-mod_wsgi \
         python3-m2crypto \
         python-devel \
+        patch \
+        patchutils \
         python-pip && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update && \
     dnf -y module reset nodejs && \
     dnf -y module enable nodejs:20 && \
     dnf -y module install nodejs:20/common && \
-    dnf -y install httpd mod_ssl python39 python-pip git procps patchutils && \
+    dnf -y install httpd mod_ssl python39 python-pip git procps patch patchutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
#331 introduced patching the UI containers, however patching fails because of missing packages:
```
Applying patch /patch/ui-dumps-banner.patch
/docker-entrypoint.sh: line 48: filterdiff: command not found
Error while filtering patch /patch/ui-dumps-banner.patch/bin. Exiting setup.
```

This PR is a follow-up to install the missing packages required for patching
