### PR TITLE
fts-cron: migrate to alma9 #340

### DIFF
--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -1,30 +1,32 @@
-FROM centos:7
+FROM almalinux:9
 
 # Repos needed for (VOMS and FTS) and WLCG certs
 ADD ca.repo /etc/yum.repos.d/ca.repo
+ADD wlcg-el9.repo /etc/yum.repos.d/wlcg-el9.repo
 
-RUN yum install -y epel-release.noarch http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+# Enable EPEL
+RUN dnf install -y yum-utils \
+  && dnf config-manager --set-enabled crb \
+  && dnf install -y epel-release
 
-RUN yum update -y && \
-    yum upgrade -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum
 
-RUN yum -y install https://repo.ius.io/ius-release-el7.rpm &&\
-    yum install -y httpd python36u-pip python36-mod_wsgi libaio gcc python36-devel.x86_64 mod_ssl openssl-devel.x86_64 python36-m2crypto libnsl.x86_64 patch.x86_64 xrootd-client && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN dnf update -y && \
+    dnf upgrade -y && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+    RUN dnf -y install -y httpd python-pip python-mod_wsgi libaio gcc python-devel mod_ssl openssl-devel python3-m2crypto libnsl patch xrootd-client && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Install latest kubectl
 RUN curl -o /usr/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 # Install VOMS and FTS clients for delegating proxies
-RUN yum -y install ca-certificates.noarch lcg-CA ca_* fetch-crl voms-clients-cpp fts-rest-cli \
+RUN dnf -y install ca-certificates.noarch ca_* fetch-crl voms-clients-cpp fts-rest-cli \
     wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-voms-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms wlcg-voms-cms \
-    python-pip python-setuptools python-requests && \
+    python-setuptools python-requests && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -32,6 +34,8 @@ RUN yum -y install ca-certificates.noarch lcg-CA ca_* fetch-crl voms-clients-cpp
 RUN yum -y install wget && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+CMD ["/bin/bash", "-c", "while true; do sleep 30; done;"]
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools

--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -24,8 +24,8 @@ RUN curl -o /usr/bin/kubectl -L https://storage.googleapis.com/kubernetes-releas
 RUN chmod +x /usr/bin/kubectl
 
 # Install VOMS and FTS clients for delegating proxies
-RUN dnf -y install ca-certificates.noarch ca_* fetch-crl voms-clients-cpp fts-rest-cli \
-    wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-voms-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms wlcg-voms-cms \
+RUN dnf -y install ca-certificates.noarch ca-policy-lcg fetch-crl voms-clients-cpp fts-rest-cli \
+    wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms \
     python-setuptools python-requests && \
     yum clean all && \
     rm -rf /var/cache/yum

--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -35,8 +35,6 @@ RUN yum -y install wget && \
     yum clean all && \
     rm -rf /var/cache/yum
 
-CMD ["/bin/bash", "-c", "while true; do sleep 30; done;"]
-
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir j2cli

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -1,32 +1,33 @@
-FROM centos:7
+FROM almalinux:9
 
 # Repos needed for (VOMS and FTS) and WLCG certs
 ADD ca.repo /etc/yum.repos.d/ca.repo
+ADD wlcg-el9.repo /etc/yum.repos.d/wlcg-el9.repo
 
-RUN yum install -y epel-release.noarch http://linuxsoft.cern.ch/wlcg/centos7/x86_64/wlcg-repo-1.0.0-1.el7.noarch.rpm && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+# Enable EPEL
+RUN dnf install -y yum-utils \
+  && dnf config-manager --set-enabled crb \
+  && dnf install -y epel-release
 
-RUN yum update -y && \
-    yum upgrade -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN dnf update -y && \
+    dnf upgrade -y && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
-RUN yum -y install https://repo.ius.io/ius-release-el7.rpm &&\
-    yum install -y httpd python36u-pip python36-mod_wsgi libaio gcc python36-devel.x86_64 mod_ssl openssl-devel.x86_64 python36-m2crypto libnsl.x86_64 patch.x86_64 xrootd-client && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+RUN dnf -y install httpd python-pip python-mod_wsgi libaio gcc python-devel mod_ssl openssl-devel python3-m2crypto libnsl patch xrootd-client && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Install latest kubectl
 RUN curl -o /usr/bin/kubectl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 # Install VOMS and FTS clients for delegating proxies
-RUN yum -y install ca-certificates.noarch lcg-CA ca_* fetch-crl voms-clients-java fts-rest-cli \
+RUN dnf -y install ca-certificates.noarch ca_* fetch-crl voms-clients-java fts-rest-cli \
     wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-voms-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms wlcg-voms-cms \
     python-pip python-setuptools python-requests && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -23,8 +23,8 @@ RUN curl -o /usr/bin/kubectl -L https://storage.googleapis.com/kubernetes-releas
 RUN chmod +x /usr/bin/kubectl
 
 # Install VOMS and FTS clients for delegating proxies
-RUN dnf -y install ca-certificates.noarch ca_* fetch-crl voms-clients-java fts-rest-cli \
-    wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-voms-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms wlcg-voms-cms \
+RUN dnf -y install ca-certificates.noarch ca-policy-lcg fetch-crl voms-clients-java fts-rest-cli \
+    wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms \
     python-pip python-setuptools python-requests && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/fts-cron/docker-entrypoint.sh
+++ b/fts-cron/docker-entrypoint.sh
@@ -40,5 +40,5 @@ if [ -z "$FETCH_CRL" -o "$FETCH_CRL" = "True" ]; then
 fi
 
 echo "=================== Delegating ========================"
-
-/opt/rucio/fts-delegate/renew_fts_proxy.sh
+# Disable the delegation for now as we are testing the alma9 setup
+# /opt/rucio/fts-delegate/renew_fts_proxy.sh

--- a/fts-cron/docker-entrypoint.sh
+++ b/fts-cron/docker-entrypoint.sh
@@ -40,5 +40,5 @@ if [ -z "$FETCH_CRL" -o "$FETCH_CRL" = "True" ]; then
 fi
 
 echo "=================== Delegating ========================"
-# Disable the delegation for now as we are testing the alma9 setup
-# /opt/rucio/fts-delegate/renew_fts_proxy.sh
+
+/opt/rucio/fts-delegate/renew_fts_proxy.sh

--- a/fts-cron/wlcg-el9.repo
+++ b/fts-cron/wlcg-el9.repo
@@ -1,0 +1,9 @@
+[wlcg]
+name=WLCG Repository
+baseurl=http://linuxsoft.cern.ch/wlcg/el9/$basearch
+protect=1
+enabled=1
+# To use priorities you must have yum-priorities installed
+priority=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg


### PR DESCRIPTION
I had to remove the `lcg-CA` package. I am not sure what it used to do and what is the alma9 alternative. 

In any case, once these changes are released, we should check if the proxy gets issued correctly on the kubernetes side. 


----

I ran the `Dockerfile_java` in the kubernetes cluster and was successfully able to generate the proxy and also the kubernetes secret


