### PR TITLE
SSH: add -p flag when running mkdir

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -22,7 +22,8 @@ RUN /usr/bin/ssh-keygen -A && \
 COPY sshd_config /etc/ssh/sshd_config
 
 # Create storage area
-RUN mkdir /rucio /root/.ssh && \
+RUN mkdir -p /rucio && \
+    mkdir -p /root/.ssh && \
     echo '' > /root/.ssh/authorized_keys
 
 # Startup


### PR DESCRIPTION
Fixing an error when building the `ssh` container:

```
 #12 [7/8] RUN mkdir /rucio /root/.ssh &&     echo '' > /root/.ssh/authorized_keys
#12 0.053 mkdir: cannot create directory '/root/.ssh': File exists
#12 ERROR: process "/bin/sh -c mkdir /rucio /root/.ssh &&     echo '' > /root/.ssh/authorized_keys" did not complete successfully: exit code: 1
```