### PR TITLE
Patch apache config to exclude OPTIONS requests from client certificate checks

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -48,9 +48,12 @@ CacheRoot /tmp
  SSLVerifyClient optional_no_ca
  SSLVerifyDepth 10
  {% if require_x509_auth %}
- <Location /auth/x509/webui>    
-    SSLVerifyClient require
-    SSLVerifyDepth 10
+ <Location /auth/x509/webui>
+  SSLVerifyClient optional
+  <LimitExcept OPTIONS>
+   SSLVerifyClient require
+  </LimitExcept>
+  SSLVerifyDepth 10
  </Location>
 {% endif %}
 {% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}


### PR DESCRIPTION
Fix #352 

At /auth/x509/webui, client certificate verification is made optional on OPTIONS requests. This will ensure proper authentication across all browsers in the new version of the UI.

