### PR TITLE
server: make SSLVerifyClient optional for /auth/x509/webui

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -51,7 +51,7 @@ CacheRoot /tmp
  <Location /auth/x509/webui>
   SSLVerifyClient optional
   <LimitExcept OPTIONS>
-   SSLVerifyClient require
+   SSLVerifyClient optional
   </LimitExcept>
   SSLVerifyDepth 10
  </Location>


### PR DESCRIPTION
The source code of webui has been changed to include client credentials in requests sent to this endpoint.