### PR TITLE
Add option to verify patching without executing daemon.

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -4,7 +4,7 @@
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-FROM almalinux:9 as rpm_builder
+FROM almalinux:9 AS rpm_builder
     RUN dnf upgrade -y
     RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch
     RUN yum-config-manager --enable crb

--- a/daemons/start-daemon.sh
+++ b/daemons/start-daemon.sh
@@ -1,37 +1,6 @@
 #!/bin/sh
 
-if [ "$USE_DAVIX_WITH_OPENSSL31" = 'True' ]; then
-    echo "=================== installing davix with openssl 3.1 ============================"
-    rpm -i /tmp/rpms/openssl31-libs-3*.rpm
-    rpm -U --force /tmp/rpms/davix-libs-0*.rpm
-fi
-
-if [ -f /opt/rucio/etc/rucio.cfg ]; then
-    echo "rucio.cfg already mounted."
-else
-    echo "rucio.cfg not found. will generate one."
-    python3 /usr/local/rucio/tools/merge_rucio_configs.py \
-        -s /tmp/rucio.config.default.cfg $RUCIO_OVERRIDE_CONFIGS \
-        --use-env \
-        -d /opt/rucio/etc/rucio.cfg
-fi
-
-if [ ! -z "$RUCIO_PRINT_CFG" ]; then
-    echo "=================== /opt/rucio/etc/rucio.cfg ============================"
-    cat /opt/rucio/etc/rucio.cfg
-    echo ""
-fi
-
-RUCIO_PYTHON_PATH=$(python3 -c "import os; import rucio; print(os.path.dirname(rucio.__file__))")
-
-/usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 &
-
-if [ "$RUCIO_DAEMON" == "hermes" ]
-then
-  echo "starting sendmail for $RUCIO_DAEMON"
-  sendmail -bd
-fi
-
+apply_patches() {
 if [ -d "/patch" ]
 then
     echo "Patches found. Trying to apply them"
@@ -42,9 +11,9 @@ then
     for patchfile in /patch/*.patch
     do
         echo "Applying patch ${patchfile}"
-        
+
         tmp_bin_file="${TMP_PATCH_DIR}/tmp_bin"
-        
+
         if ! filterdiff -i '*/bin/*' "${patchfile}" > ${tmp_bin_file}; then
             echo "Error while filtering patch ${patchfile}/bin. Exiting setup."
             exit 1
@@ -79,6 +48,49 @@ then
             fi
         fi
     done
+else
+  echo "Patches not found"
+fi
+}
+
+if [ "$USE_DAVIX_WITH_OPENSSL31" = 'True' ]; then
+    echo "=================== installing davix with openssl 3.1 ============================"
+    rpm -i /tmp/rpms/openssl31-libs-3*.rpm
+    rpm -U --force /tmp/rpms/davix-libs-0*.rpm
+fi
+
+if [ -f /opt/rucio/etc/rucio.cfg ]; then
+    echo "rucio.cfg already mounted."
+else
+    echo "rucio.cfg not found. will generate one."
+    python3 /usr/local/rucio/tools/merge_rucio_configs.py \
+        -s /tmp/rucio.config.default.cfg $RUCIO_OVERRIDE_CONFIGS \
+        --use-env \
+        -d /opt/rucio/etc/rucio.cfg
+fi
+
+if [ ! -z "$RUCIO_PRINT_CFG" ]; then
+    echo "=================== /opt/rucio/etc/rucio.cfg ============================"
+    cat /opt/rucio/etc/rucio.cfg
+    echo ""
+fi
+
+RUCIO_PYTHON_PATH=$(python3 -c "import os; import rucio; print(os.path.dirname(rucio.__file__))")
+
+if [[ "${RUCIO_DAEMON_ONLY_CHECK_PATCHES}" ]];
+  then
+    apply_patches
+    exit 0
+fi
+
+/usr/bin/memcached -u memcached -p 11211 -m 64 -c 1024 &
+
+apply_patches
+
+if [ "$RUCIO_DAEMON" == "hermes" ]
+then
+  echo "starting sendmail for $RUCIO_DAEMON"
+  sendmail -bd
 fi
 
 if [ -d /etc/grid-security/certificates ]; then


### PR DESCRIPTION
Fixes #362

Example:
```
docker buildx build --build-arg TAG=36.0.0 --file ./daemons/Dockerfile  daemons/ --tag myrucio
```

Applies patches if any and starts daemon
```
docker run -e RUCIO_DAEMON=hermes myrucio
$ docker run -e RUCIO_DAEMON=hermes myrucio
=================== installing davix with openssl 3.1 ============================
rucio.cfg not found. will generate one.
INFO:root:Merged 74 configuration values from /tmp/rucio.config.default.cfg
INFO:root:Merged 0 configuration values from ENV
INFO:root:Writing /opt/rucio/etc/rucio.cfg
Patches not found
starting sendmail for hermes
....
....
```

Only applies patches:
```
$ docker run -e RUCIO_DAEMON_ONLY_CHECK_PATCHES=1 myrucio
=================== installing davix with openssl 3.1 ============================
rucio.cfg not found. will generate one.
INFO:root:Merged 74 configuration values from /tmp/rucio.config.default.cfg
INFO:root:Merged 0 configuration values from ENV
INFO:root:Writing /opt/rucio/etc/rucio.cfg
Patches not found
$ echo $?
0
```


