### PR TITLE
Add arm64 as build target for supported images

### DIFF
--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -48,10 +48,10 @@ jobs:
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -250,7 +250,7 @@ jobs:
       - name: Build and push
         if: steps.release.outputs.tags != ''
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6.13.0
         with:
           context: ./${{ steps.release.outputs.context_dir }}
           file: ./${{ steps.release.outputs.context_dir }}/${{ steps.release.outputs.file }}

--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -254,6 +254,7 @@ jobs:
         with:
           context: ./${{ steps.release.outputs.context_dir }}
           file: ./${{ steps.release.outputs.context_dir }}/${{ steps.release.outputs.file }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: '${{ steps.release.outputs.tags }}'
           build-args: TAG=${{ steps.release.outputs.git_tag }}

--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -247,6 +247,15 @@ jobs:
 
           echo "For tag: $GIT_TAG, the following images will be pushed: $TAGS_TO_PUSH"
 
+      - name: Determine target platforms
+        id: determine_target_platforms
+        run: |
+          if [[ "${{ matrix.context }}" =~ "test-fts" || "${{ matrix.context }}" =~ "probes" ]]; then
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+          else
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         if: steps.release.outputs.tags != ''
         id: docker_build
@@ -254,8 +263,8 @@ jobs:
         with:
           context: ./${{ steps.release.outputs.context_dir }}
           file: ./${{ steps.release.outputs.context_dir }}/${{ steps.release.outputs.file }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.determine_target_platforms.outputs.platforms }}
           push: true
           tags: '${{ steps.release.outputs.tags }}'
           build-args: TAG=${{ steps.release.outputs.git_tag }}
-  
+

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -4,21 +4,6 @@
 # You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-FROM almalinux:9 as rpm_builder
-    RUN dnf upgrade -y
-    RUN dnf install -y rpm-build rpmdevtools yum-utils epel-release.noarch
-    RUN yum-config-manager --enable crb
-    # BUILD and install openssl 3.1
-    ADD openssl.spec    /root/rpmbuild/SPECS/openssl.spec
-    RUN yum-builddep -y /root/rpmbuild/SPECS/openssl.spec
-    RUN spectool -g     /root/rpmbuild/SPECS/openssl.spec --directory /root/rpmbuild/SOURCES/
-    RUN rpmbuild -bb    /root/rpmbuild/SPECS/openssl.spec
-    RUN dnf install -y  /root/rpmbuild/RPMS/*/*
-    # REBUILD davix to use openssl 3.1
-    RUN yumdownloader --source davix
-    RUN yum-builddep -y --srpm davix*.src.rpm
-    RUN rpmbuild --rebuild davix-*.src.rpm
-
 FROM almalinux:9
 
 ARG TAG
@@ -63,8 +48,6 @@ ADD start-daemon.sh /
 RUN update-crypto-policies --set DEFAULT:SHA1
 
 RUN mkdir /var/log/rucio
-
-COPY --from=rpm_builder /root/rpmbuild/RPMS/x86_64/*.rpm /tmp/rpms/
 
 VOLUME /var/log/rucio
 VOLUME /opt/rucio/etc

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -33,6 +33,15 @@ RUN dnf install -y epel-release.noarch && \
         xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
+
+# cx_oracle requires `gcc` and Python headers, not present by default on arm64
+ARG TARGETARCH
+RUN if [ $TARGETARCH = "arm64" ]; then \
+        dnf install -y \
+            gcc \
+            python3-devel \
+    ; fi
+
 RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
     echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -24,6 +24,16 @@ RUN dnf install -y epel-release.noarch && \
         patchutils && \
     dnf clean all && \
     rm -rf /var/cache/dnf
+
+# cx_oracle requires `gcc` and Python headers, not present by default on arm64
+ARG TARGETARCH
+RUN if [ $TARGETARCH = "arm64" ]; then \
+        dnf install -y \
+            gcc \
+            python3-devel \
+    ; fi
+
+
 RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
     echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
     ldconfig

--- a/test-xrootd/Dockerfile
+++ b/test-xrootd/Dockerfile
@@ -3,6 +3,7 @@ FROM almalinux:9
 # Install CERN CA
 ADD ca.repo /etc/yum.repos.d/ca.repo
 
+# WLCG repo is the same for x86_64 and aarch64
 RUN dnf install -y epel-release.noarch https://linuxsoft.cern.ch/wlcg/el9/x86_64/wlcg-repo-1.0.0-1.el9.noarch.rpm && \
     dnf update -y && \
     dnf upgrade -y && \


### PR DESCRIPTION
- de7b51e7d0828dbd839f45b2cadde340e4bfdb0f fixes https://github.com/rucio/containers/issues/365
- the other commits address https://github.com/rucio/containers/issues/354

The only two unsupported images are currently:
- `test-fts` - FTS doesn't provide an arm-based image
- `probes`: pending https://github.com/rucio/containers/issues/369

Related: https://github.com/rucio/rucio/issues/7162 - we would need to change this PR to only set `amd64` for `test-fts` and `probes`.

