### PR TITLE
server,clients,daemons,ui,init: add policy package build arg support

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -45,5 +45,19 @@ ADD --chown=user;user ./entrypoint.sh /opt/user/entrypoint.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 
+ARG POLICY_PACKAGE_REQUIREMENTS
+ARG USER=root
+USER root
+RUN if [ -n "$POLICY_PACKAGE_REQUIREMENTS" ]; then \
+        dnf install -y git && \
+        for package in $(echo $POLICY_PACKAGE_REQUIREMENTS | tr "," "\n"); do \
+            python3 -m pip install --no-cache-dir $package; \
+        done; \
+        dnf remove -y git && \
+        dnf autoremove && \
+        dnf clean all; \
+    fi
+USER ${USER}
+
 ENTRYPOINT ["/opt/user/entrypoint.sh"]
 CMD ["bash"]

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -63,4 +63,18 @@ VOLUME /opt/rucio/etc
 
 ENV USE_DAVIX_WITH_OPENSSL31=True
 
+ARG POLICY_PACKAGE_REQUIREMENTS
+ARG USER=root
+USER root
+RUN if [ -n "$POLICY_PACKAGE_REQUIREMENTS" ]; then \
+        dnf install -y git && \
+        for package in $(echo $POLICY_PACKAGE_REQUIREMENTS | tr "," "\n"); do \
+            python3 -m pip install --no-cache-dir $package; \
+        done; \
+        dnf remove -y git && \
+        dnf autoremove && \
+        dnf clean all; \
+    fi
+USER ${USER}
+
 ENTRYPOINT ["/start-daemon.sh"]

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -34,4 +34,18 @@ COPY alembic.ini.j2 /tmp
 COPY bootstrap.py /tmp
 COPY docker-entrypoint.sh /
 
+ARG POLICY_PACKAGE_REQUIREMENTS
+ARG USER=root
+USER root
+RUN if [ -n "$POLICY_PACKAGE_REQUIREMENTS" ]; then \
+        dnf install -y git && \
+        for package in $(echo $POLICY_PACKAGE_REQUIREMENTS | tr "," "\n"); do \
+            python3 -m pip install --no-cache-dir $package; \
+        done; \
+        dnf remove -y git && \
+        dnf autoremove && \
+        dnf clean all; \
+    fi
+USER ${USER}
+
 CMD ["/docker-entrypoint.sh"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -65,4 +65,18 @@ VOLUME /opt/rucio/etc
 EXPOSE 80
 EXPOSE 443
 
+ARG POLICY_PACKAGE_REQUIREMENTS
+ARG USER=root
+USER root
+RUN if [ -n "$POLICY_PACKAGE_REQUIREMENTS" ]; then \
+        dnf install -y git && \
+        for package in $(echo $POLICY_PACKAGE_REQUIREMENTS | tr "," "\n"); do \
+            python3 -m pip install --no-cache-dir $package; \
+        done; \
+        dnf remove -y git && \
+        dnf autoremove && \
+        dnf clean all; \
+    fi
+USER ${USER}
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -56,4 +56,18 @@ VOLUME /opt/rucio/etc
 EXPOSE 80
 EXPOSE 443
 
+ARG POLICY_PACKAGE_REQUIREMENTS
+ARG USER=root
+USER root
+RUN if [ -n "$POLICY_PACKAGE_REQUIREMENTS" ]; then \
+        dnf install -y git && \
+        for package in $(echo $POLICY_PACKAGE_REQUIREMENTS | tr "," "\n"); do \
+            python3 -m pip install --no-cache-dir $package; \
+        done; \
+        dnf remove -y git && \
+        dnf autoremove && \
+        dnf clean all; \
+    fi
+USER ${USER}
+
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Fixes #364

I haven't modified the container READMEs for now. I plan to mostly include info on policy package deployments in the main policy package docs, under this other issue https://github.com/rucio/documentation/issues/456

Example usage:
```
docker build --no-cache -t test-server --build-arg POLICY_PACKAGE_REQUIREMENTS=atlas_rucio_policy_package==0.4.0,git+https://github.com/rucio/temporary-belle2-policy-package@v0.1.0 --build-arg TAG=36.2.0 .
```

Verifying installation (this is after importing the modules):
```
>>> rucio
<module 'rucio' from '/usr/local/lib/python3.9/site-packages/rucio/__init__.py'>
>>> atlas_rucio_policy_package
<module 'atlas_rucio_policy_package' from '/usr/local/lib/python3.9/site-packages/atlas_rucio_policy_package/__init__.py'>
>>> belleii_rucio_policy_package
<module 'belleii_rucio_policy_package' from '/usr/local/lib/python3.9/site-packages/belleii_rucio_policy_package/__init__.py'>
```