### PR TITLE
Add GitHub Actions workflow to verify Docker Hub secrets

### DIFF
--- a/.github/workflows/test-secrets.yml
+++ b/.github/workflows/test-secrets.yml
@@ -1,0 +1,36 @@
+name: org-secrets
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify Secrets are set
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        run: |
+          if [ -z "${{ secrets.DOCKER_HUB_USERNAME }}" ]; then
+            echo "DOCKER_HUB_USERNAME is not set. Exiting!"
+            exit 1
+          fi
+          if [ -z "${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}" ]; then
+            echo "DOCKER_HUB_ACCESS_TOKEN is not set. Exiting!"
+            exit 1
+          fi
+      - name: Verify Length of Secrets is not zero
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+        run: |
+          if [ ${#DOCKER_HUB_USERNAME} -eq 0 ]; then
+            echo "DOCKER_HUB_USERNAME is not set. Exiting!"
+            exit 1
+          fi
+          if [ ${#DOCKER_HUB_ACCESS_TOKEN} -eq 0 ]; then
+            echo "DOCKER_HUB_ACCESS_TOKEN is not set. Exiting!"
+            exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to verify the presence and length of Docker Hub secrets. The most important change is the addition of the `test-secrets.yml` file, which ensures that the necessary secrets are set correctly before proceeding with the workflow.

New GitHub Actions workflow:

* [`.github/workflows/test-secrets.yml`](diffhunk://#diff-4486b6de4b04c48ae0ff174051848d627fa5126508c21c5eeb8133dff003e806R1-R36): Added a workflow named `org-secrets` that runs on pull requests and manual triggers. It includes steps to verify that `DOCKER_HUB_USERNAME` and `DOCKER_HUB_ACCESS_TOKEN` secrets are set and have non-zero length.