### PR TITLE
Pin dev image version Fix #379

### DIFF
--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -108,7 +108,7 @@ jobs:
           CONTEXT_DIR=$(echo "${CONTEXT}" | cut -d, -f1 )
           PARENT=$(echo "${CONTEXT}" | cut -d, -f2 | xargs)
           GIT_TAG=${{ steps.release_tag.outputs.version }}
-          BASE_TAG="${{ github.repository_owner}}/"
+          BASE_TAG="${{ secrets.DOCKER_HUB_USERNAME }}/"
           PARENT_IMAGE_AVAILIBILITY_INTERVAL=60
           MAX_ATTEMPTS=10
           GIT_TAG_COMMIT_SHA=$(echo $(git rev-list -n 1 $GIT_TAG))
@@ -223,7 +223,7 @@ jobs:
             PARENT=${PARENT/\#TAG/$GIT_TAG}
             fi
 
-            PARENT="${{ github.repository_owner }}/${PARENT}"
+            PARENT="${{ secrets.DOCKER_HUB_USERNAME }}/${PARENT}"
             for i in $(seq 1 1 $MAX_ATTEMPTS)
             do
                 echo "Attempt ${i}: Waiting for $PARENT to be available on Docker Hub"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -14,6 +14,11 @@
 
 FROM almalinux:9
 
+ARG TAG
+
+# Fail early if TAG is not provided
+RUN test -n "$TAG" || (echo "No TAG specified. Exiting." && exit 1)
+
 WORKDIR /
 
 RUN dnf -y install yum-utils epel-release.noarch && \
@@ -57,9 +62,7 @@ RUN dnf -y install yum-utils epel-release.noarch && \
 
 RUN curl https://rclone.org/install.sh | bash
 
-ARG GIT_CLONE_ARGS="--depth 1 https://github.com/rucio/rucio.git"
-
-RUN git clone $GIT_CLONE_ARGS /tmp/rucio && rm -rf /tmp/rucio/.git
+RUN git clone --depth 1 --branch "$TAG" https://github.com/rucio/rucio.git /tmp/rucio && rm -rf /tmp/rucio/.git
 
 ENV RUCIOHOME=/opt/rucio
 RUN mkdir -p $RUCIOHOME && \


### PR DESCRIPTION
Pin rucio-dev image using ARG TAG, with early failing if no tag is provided.

Also, previously, the workflow used `github.repository_owner` when constructing Docker image tags, which caused push failures if the GitHub username did not match the Docker Hub username. This commit switches to using the `DOCKER_HUB_USERNAME` secret for the base tag. This should not affect actually any official build process where both usernames are identical (hence, the Docker Hub namespace should remain correct). The change is mostly for dev support.