### PR TITLE
dev: set master branch to default arg for pulling

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -14,10 +14,7 @@
 
 FROM almalinux:9
 
-ARG TAG
-
-# Fail early if TAG is not provided
-RUN test -n "$TAG" || (echo "No TAG specified. Exiting." && exit 1)
+ARG TAG="master"
 
 WORKDIR /
 


### PR DESCRIPTION
Should fix the end-to-end tests

```
#7 [ 2/31] RUN test -n "$TAG" || (echo "No TAG specified. Exiting." && exit 1)
#7 0.208 No TAG specified. Exiting.
```

this should be fixed by merging https://github.com/rucio/rucio/pull/7500 anyway, but I think it's a good idea to set the master branch as default