### PR TITLE
dev: Update database connection string to use postgresql+psycopg

### DIFF
--- a/dev/alembic.ini
+++ b/dev/alembic.ini
@@ -25,7 +25,7 @@ script_location = lib/rucio/db/sqla/migrate_repo/
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://rucio:secret@ruciodb/rucio
+sqlalchemy.url = postgresql+psycopg://rucio:secret@ruciodb/rucio
 version_table_schema = dev
 
 # Logging configuration

--- a/dev/rucio.cfg
+++ b/dev/rucio.cfg
@@ -17,7 +17,7 @@ account = root
 request_retries = 3
 
 [database]
-default = postgresql://rucio:secret@ruciodb/rucio
+default = postgresql+psycopg://rucio:secret@ruciodb/rucio
 schema = dev
 echo=0
 pool_recycle=3600

--- a/dev/rucio_multi_vo_ts2.cfg
+++ b/dev/rucio_multi_vo_ts2.cfg
@@ -19,7 +19,7 @@ request_retries = 3
 vo = ts2
 
 [database]
-default = postgresql://rucio:secret@ruciodb/rucio
+default = postgresql+psycopg://rucio:secret@ruciodb/rucio
 schema = dev
 echo=0
 pool_recycle=3600

--- a/dev/rucio_multi_vo_tst.cfg
+++ b/dev/rucio_multi_vo_tst.cfg
@@ -19,7 +19,7 @@ request_retries = 3
 vo = tst
 
 [database]
-default = postgresql://rucio:secret@ruciodb/rucio
+default = postgresql+psycopg://rucio:secret@ruciodb/rucio
 schema = dev
 echo=0
 pool_recycle=3600


### PR DESCRIPTION
This pull request includes several changes to update the database connection URL to use `psycopg` instead of the default PostgreSQL adapter. These changes are made across multiple configuration files to ensure consistency.

This was the root cause behind the dev containers not starting up as they were using the incorrect driver to connect to the database.

Database connection URL updates:

* [`dev/alembic.ini`](diffhunk://#diff-1e7a48965b7b7d1ce5f811c504381194b579f2f7bb31f6be108e434138adaf51L28-R28): Updated the `sqlalchemy.url` to use `postgresql+psycopg` instead of `postgresql`.
* [`dev/rucio.cfg`](diffhunk://#diff-9f7058724fb0d51f1d2b36a4ed4e0c30c79872dc12fd2c7470f363b9a234a04aL20-R20): Updated the `default` database URL to use `postgresql+psycopg` instead of `postgresql`.
* [`dev/rucio_multi_vo_ts2.cfg`](diffhunk://#diff-0808314482db7fcd945e590cb58b6ecee957095709f773622565e16ff71814a1L22-R22): Updated the `default` database URL to use `postgresql+psycopg` instead of `postgresql`.
* [`dev/rucio_multi_vo_tst.cfg`](diffhunk://#diff-e6f8bbe1749788ea19a76cc8101e73d15d808b1ad4d936429a01df6c3d1ccbccL22-R22): Updated the `default` database URL to use `postgresql+psycopg` instead of `postgresql`.