### PR TITLE
Add support for `AllowEncodedSlashes NoDecode` via new env variable

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -82,7 +82,9 @@ CacheRoot /tmp
  ErrorLog /dev/stderr
 {% endif %}
 
-{% if RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
+{% if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE|default('False') == 'True' %}
+ AllowEncodedSlashes NoDecode
+{% elif RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
  AllowEncodedSlashes on
 {% endif %}
 


### PR DESCRIPTION
Same default behaviour as before, this change preserves backwards compatibility.

Relted to https://github.com/rucio/containers/issues/392