### PR TITLE
CI: run ShellCheck on pushes too

### DIFF
--- a/.github/workflows/shell-check.yml
+++ b/.github/workflows/shell-check.yml
@@ -4,6 +4,7 @@ run-name: ShellCheck
 
 on:
   pull_request:
+  push:
 
 jobs:
   shellcheck:


### PR DESCRIPTION
This is similar to the hooks for the workflows in the main repository. I don't think it's worth adding a nightly run too - it makes sense for the main repo's tests, but in this case, it's probably enough to just check on PRs and pushes. Because we're pinning the version of the ShellCheck action, I don't think the nightly would ever fail independently, because the version will have to be updated by a PR anyway (likely by Dependabot), and in the case that a new version of ShellCheck makes the test fail, it will fail in the PR.