### PR TITLE
Remove Oracle Instant Client from Dockerfiles; Fix #419

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -34,20 +34,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# cx_oracle requires `gcc` and Python headers, not present by default on arm64
-ARG TARGETARCH
-RUN if [ $TARGETARCH = "arm64" ]; then \
-        dnf install -y \
-            gcc \
-            python3-devel && \
-        dnf clean all && \
-        rm -rf /var/cache/dnf; \
-    fi
-
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 # Downgrade setuptools to avoid compatibility issues
 # TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
 RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -19,10 +19,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 # Downgrade setuptools to avoid compatibility issues
 # TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
 RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -27,10 +27,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.0/jobber-1.4.0-1.el7.x86_64.rpm
 
 # Downgrade setuptools to avoid compatibility issues

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,21 +25,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# cx_oracle requires `gcc` and Python headers, not present by default on arm64
-ARG TARGETARCH
-RUN if [ $TARGETARCH = "arm64" ]; then \
-        dnf install -y \
-            gcc \
-            python3-devel && \
-        dnf clean all && \
-        rm -rf /var/cache/dnf; \
-    fi
-
-
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 # Downgrade setuptools to avoid compatibility issues
 # TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
 RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -32,10 +32,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 # Downgrade setuptools to avoid compatibility issues
 # TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
 RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm


### PR DESCRIPTION
Removes Oracle Instant Client and dependencies that have been specified as required by it only.
The affected containers are:
  - `daemons`
  - `init`
  - `probes`
  - `server`
  - `ui`
  
  however, would we prefer to keep the client in some of those for backwards compatibility (e.g. in `probes`)? Not sure. If so, I can leave it (may adding an inline comment that this needs to be removed in 2 years).