### PR TITLE
Update dependencies; Fix #425

### DIFF
--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -1,3 +1,9 @@
+# Copyright European Organization for Nuclear Research (CERN) 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 FROM almalinux:9
 
 ARG TAG

--- a/clients/Dockerfile
+++ b/clients/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /home/user
 # Add the default rucio configuration
 ADD --chown=user:user rucio.default.cfg /opt/user/rucio.default.cfg
 ADD init_rucio.sh /etc/profile.d/rucio_init.sh
-ADD --chown=user;user ./entrypoint.sh /opt/user/entrypoint.sh
+ADD --chown=user:user ./entrypoint.sh /opt/user/entrypoint.sh
 
 ENV PATH $PATH:/opt/rucio/bin
 

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -19,8 +19,6 @@ RUN dnf install -y epel-release.noarch && \
         gfal2-plugin-http \
         gfal2-plugin-srm \
         gfal2-plugin-xrootd \
-        libnsl \
-        libaio \
         patch \
         python-gfal2 \
         procps-ng \

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -22,8 +22,8 @@ RUN dnf install -y epel-release.noarch && \
         patch \
         python-gfal2 \
         procps-ng \
-        python-pip \
-        python-mod_wsgi \
+        python3-pip \
+        python3-mod_wsgi \
         sendmail \
         sendmail-cf \
         memcached \

--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -34,18 +34,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# cx_oracle requires `gcc` and Python headers, not present by default on arm64
-ARG TARGETARCH
-RUN if [ $TARGETARCH = "arm64" ]; then \
-        dnf install -y \
-            gcc \
-            python3-devel \
-    ; fi
-
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql,globus]==$TAG

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -30,7 +30,6 @@ RUN dnf -y install yum-utils epel-release.noarch && \
         gridsite \
         httpd \
         krb5-devel \
-        libaio \
         libtool-ltdl-devel \
         libxml2-devel \
         mariadb-connector-c \

--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -15,7 +15,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-    RUN dnf -y install -y httpd python-pip python-mod_wsgi gcc python-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
+    RUN dnf -y install -y httpd python3-pip python3-mod_wsgi gcc python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -15,7 +15,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-    RUN dnf -y install -y httpd python3-pip python3-mod_wsgi gcc python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
+    RUN dnf -y install -y httpd python3-pip python3-mod_wsgi python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/fts-cron/Dockerfile_cpp
+++ b/fts-cron/Dockerfile_cpp
@@ -15,7 +15,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-    RUN dnf -y install -y httpd python-pip python-mod_wsgi libaio gcc python-devel mod_ssl openssl-devel python3-m2crypto libnsl patch xrootd-client && \
+    RUN dnf -y install -y httpd python-pip python-mod_wsgi gcc python-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -14,7 +14,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN dnf -y install httpd python3-pip python3-mod_wsgi gcc python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
+RUN dnf -y install httpd python3-pip python3-mod_wsgi python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -14,7 +14,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN dnf -y install httpd python-pip python-mod_wsgi gcc python-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
+RUN dnf -y install httpd python3-pip python3-mod_wsgi gcc python3-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
@@ -25,7 +25,7 @@ RUN chmod +x /usr/bin/kubectl
 # Install VOMS and FTS clients for delegating proxies
 RUN dnf -y install ca-certificates.noarch ca-policy-lcg fetch-crl voms-clients-java fts-rest-cli \
     wlcg-iam-lsc-atlas wlcg-iam-vomses-atlas wlcg-iam-lsc-cms wlcg-iam-vomses-cms \
-    python-pip python-setuptools python-requests && \
+    python3-pip python-setuptools python-requests && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/fts-cron/Dockerfile_java
+++ b/fts-cron/Dockerfile_java
@@ -14,7 +14,7 @@ RUN dnf update -y && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN dnf -y install httpd python-pip python-mod_wsgi libaio gcc python-devel mod_ssl openssl-devel python3-m2crypto libnsl patch xrootd-client && \
+RUN dnf -y install httpd python-pip python-mod_wsgi gcc python-devel mod_ssl openssl-devel python3-m2crypto patch xrootd-client && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -8,8 +8,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
         gcc \
-        libnsl \
-        libaio \
         openssl-devel \
         mod_ssl \
         procps-ng \

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,3 +1,9 @@
+# Copyright European Organization for Nuclear Research (CERN) 2025
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
 FROM almalinux:9
 
 ARG TAG

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /tmp
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
-        gcc \
         openssl-devel \
         mod_ssl \
         procps-ng \

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -19,9 +19,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --pre rucio[oracle,mysql,postgresql]==$TAG

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -11,9 +11,9 @@ RUN dnf install -y epel-release.noarch && \
         openssl-devel \
         mod_ssl \
         procps-ng \
-        python-devel \
+        python3-devel \
         python3-m2crypto \
-        python-pip && \
+        python3-pip && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -26,10 +26,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 RUN rpm -i https://github.com/dshearer/jobber/releases/download/v1.4.0/jobber-1.4.0-1.el7.x86_64.rpm
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -19,8 +19,8 @@ RUN dnf install -y epel-release.noarch && \
         gcc \
         openssl-devel \
         procps-ng \
-        python-devel \
-        python-pip && \
+        python3-devel \
+        python3-pip && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -17,8 +17,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf install -y \
         git \
         gcc \
-        libnsl \
-        libaio \
         openssl-devel \
         procps-ng \
         python-devel \

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -16,7 +16,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
         git \
-        gcc \
         openssl-devel \
         procps-ng \
         python3-devel \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,8 +14,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
         gridsite \
-        libnsl \
-        libaio \
         patch \
         procps-ng \
         python-pip \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,8 +16,8 @@ RUN dnf install -y epel-release.noarch && \
         gridsite \
         patch \
         procps-ng \
-        python-pip \
-        python-mod_wsgi \
+        python3-pip \
+        python3-mod_wsgi \
         memcached \
         patchutils && \
     dnf clean all && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,19 +25,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# cx_oracle requires `gcc` and Python headers, not present by default on arm64
-ARG TARGETARCH
-RUN if [ $TARGETARCH = "arm64" ]; then \
-        dnf install -y \
-            gcc \
-            python3-devel \
-    ; fi
-
-
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
-
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG

--- a/test-ssh/Dockerfile
+++ b/test-ssh/Dockerfile
@@ -3,7 +3,6 @@ FROM almalinux:9
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
-        gcc \
         openssh-server \
         openssh-clients \
         python3-pip \

--- a/test-ssh/Dockerfile
+++ b/test-ssh/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf install -y epel-release.noarch && \
         gcc \
         openssh-server \
         openssh-clients \
-        python-pip \
+        python3-pip \
         rsync \
         sudo \
         unzip && \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -32,9 +32,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN rpm -i https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm; \
-    echo "/usr/lib/oracle/19/client64/lib" >/etc/ld.so.conf.d/oracle.conf; \
-    ldconfig
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -16,7 +16,6 @@ WORKDIR /tmp
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
-        gcc \
         httpd \
         openssl-devel \
         mod_ssl \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -18,8 +18,6 @@ RUN dnf install -y epel-release.noarch && \
     dnf install -y \
         gcc \
         httpd \
-        libnsl \
-        libaio \
         openssl-devel \
         mod_ssl \
         procps-ng \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -23,10 +23,10 @@ RUN dnf install -y epel-release.noarch && \
         procps-ng \
         python3-mod_wsgi \
         python3-m2crypto \
-        python-devel \
+        python3-devel \
         patch \
         patchutils \
-        python-pip && \
+        python3-pip && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y update && \
     dnf -y module reset nodejs && \
     dnf -y module enable nodejs:20 && \
     dnf -y module install nodejs:20/common && \
-    dnf -y install httpd mod_ssl python39 python-pip git procps patch patchutils && \
+    dnf -y install httpd mod_ssl python39 python3-pip git procps patch patchutils && \
     dnf -y install wget && \
     dnf clean all && \
     rm -rf /var/cache/dnf


### PR DESCRIPTION
**Draft Notice:** There is progress here but kept for now frozen until [#8248](https://github.com/rucio/rucio/issues/8248) is closed.
---

This commit basically cleans up a bit the project's Docker container definitions.
- It removes several packages that are no longer needed, such as , `gcc`, `libnsl`, and `libaio` (similar to https://github.com/rucio/rucio/pull/7867), which were likely required by `cx_oracle` only.
- It standardizes the Python package installations to use the `python3` versions, for example, by replacing `python-pip` with `python3-pip`.
- Additionally, a minor typo in a file copy command was corrected, and license headers were added to some files.

Although I tested locally that the images are built successfully, it is important to test them while being used because in practice things might break during runtime too.

**Couple extra points:**
- It would be nice if we had a way to track which package requires what dependencies.
- It would be nice to have some CI/testing workflow where the pushed changes are evaluated in practice.
