### PR TITLE
Apache: Switch app to the global interpreter for `oracledb` support

### DIFF
--- a/dev/rucio.conf
+++ b/dev/rucio.conf
@@ -4,7 +4,8 @@ Listen 443
 
 WSGIRestrictEmbedded On
 WSGIDaemonProcess rucio processes=4 threads=4
-WSGIApplicationGroup rucio
+WSGIProcessGroup rucio
+WSGIApplicationGroup %{GLOBAL}
 
 <VirtualHost *:443>
 
@@ -43,12 +44,12 @@ WSGIApplicationGroup rucio
  # Rucio WebUI
  Alias  /media             /opt/rucio/lib/rucio/web/ui/media
  Alias  /static            /opt/rucio/lib/rucio/web/ui/static
- WSGIScriptAlias  /ui      /opt/rucio/lib/rucio/web/ui/main.py process-group=rucio application-group=rucio
+ WSGIScriptAlias  /ui      /opt/rucio/lib/rucio/web/ui/main.py
 
  # Prometheus Metrics
- WSGIScriptAlias  /metrics /opt/rucio/lib/rucio/web/rest/metrics.py process-group=rucio application-group=rucio
+ WSGIScriptAlias  /metrics /opt/rucio/lib/rucio/web/rest/metrics.py
 
  # Rucio Flask REST API
- WSGIScriptAlias  /        /opt/rucio/lib/rucio/web/rest/main.py process-group=rucio application-group=rucio
+ WSGIScriptAlias  /        /opt/rucio/lib/rucio/web/rest/main.py
 
 </VirtualHost>

--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -24,7 +24,8 @@ LoadModule cache_disk_module modules/mod_cache_disk.so
 
 WSGIRestrictEmbedded On
 WSGIDaemonProcess rucio processes={{ RUCIO_WSGI_DAEMON_PROCESSES | default('4') }} threads={{ RUCIO_WSGI_DAEMON_THREADS | default('4') }}
-WSGIApplicationGroup rucio
+WSGIProcessGroup rucio
+WSGIApplicationGroup %{GLOBAL}
 
 CacheEnable disk /
 CacheRoot /tmp
@@ -98,7 +99,7 @@ CacheRoot /tmp
 {% if RUCIO_DEFINE_ALIASES|default('False') == 'True' %}
  Include /opt/rucio/etc/aliases.conf
 {% else %}
- WSGIScriptAlias / {{ RUCIO_PYTHON_PATH }}/web/rest/flaskapi/v1/main.py process-group=rucio application-group=rucio
+ WSGIScriptAlias / {{ RUCIO_PYTHON_PATH }}/web/rest/flaskapi/v1/main.py
 {% endif %}
 
 {% if RUCIO_HTTPD_PROXY_PROTOCOL_ENABLED | default('False') == 'True' %}
@@ -122,7 +123,7 @@ Listen {{ RUCIO_METRICS_PORT }}
 <VirtualHost *:{{ RUCIO_METRICS_PORT }} >
 {{ common_virtual_host_config(port=RUCIO_METRICS_PORT, enable_ssl=false) }}
 
- WSGIScriptAlias /metrics {{ RUCIO_PYTHON_PATH }}/web/rest/metrics.py process-group=rucio application-group=rucio
+ WSGIScriptAlias /metrics {{ RUCIO_PYTHON_PATH }}/web/rest/metrics.py
 </VirtualHost>
 {% endif %}
 
@@ -131,6 +132,6 @@ Listen {{ RUCIO_HEALTH_CHECK_PORT }}
 <VirtualHost *:{{ RUCIO_HEALTH_CHECK_PORT }} >
 {{ common_virtual_host_config(port=RUCIO_HEALTH_CHECK_PORT, enable_ssl=RUCIO_ENABLE_SSL|default('False') == 'True', require_x509_auth=false) }}
 
- WSGIScriptAlias /ping {{ RUCIO_PYTHON_PATH }}/web/rest/ping.py process-group=rucio application-group=rucio
+ WSGIScriptAlias /ping {{ RUCIO_PYTHON_PATH }}/web/rest/ping.py
 </VirtualHost>
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/rucio/containers/issues/428

**Things to note:**
- I know that there is a request from ATLAS for including Oracle's Instant Client because things break without it (I am working also on that for pushing an update to make things more dynamic and allow both thin/thick mode). However, I was wondering, whether the introduced changes might fix things for ATLAS (avoiding the need for the thick mode). Small chance but worth asking :/ 

- I built a dev image locally with the introduced changes and now Rucio seems to be working as expected with tests running. However, since this involves a change also to many other images (due to the modification of the template), we should test this more globally.