### PR TITLE
docker-auto-build: migrate from deprecated set-output syntax

### DIFF
--- a/.github/workflows/docker-auto-build.yml
+++ b/.github/workflows/docker-auto-build.yml
@@ -45,7 +45,7 @@ jobs:
       
       - name: Get the release tag from GitHub
         id: release_tag
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
@@ -240,10 +240,10 @@ jobs:
           fi
   
 
-          echo ::set-output name=git_tag::$GIT_TAG
-          echo ::set-output name=tags::$TAGS_TO_PUSH
-          echo ::set-output name=context_dir::$CONTEXT_DIR
-          echo ::set-output name=file::$FILE
+          echo "git_tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          echo "tags=$TAGS_TO_PUSH" >> $GITHUB_OUTPUT
+          echo "context_dir=$CONTEXT_DIR" >> $GITHUB_OUTPUT
+          echo "file=$FILE" >> $GITHUB_OUTPUT
 
           echo "For tag: $GIT_TAG, the following images will be pushed: $TAGS_TO_PUSH"
 


### PR DESCRIPTION
#439