### PR TITLE
Update multi-vo fts renew script; Fix #177

### DIFF
--- a/fts-cron/renew_fts_proxy_multi_vo.sh.j2
+++ b/fts-cron/renew_fts_proxy_multi_vo.sh.j2
@@ -1,36 +1,41 @@
 #!/bin/bash
 
-{% if RUCIO_FTS_VOMSES is defined %}
-{% set vomses = RUCIO_FTS_VOMSES.split(',') %}
-{% for voms in vomses %}
 
-printf "=================== {{ voms }} Renewal =========================\n\n"
+{% set ns = namespace(secrets='') %}
+{% set VO_COUNT = RUCIO_FTS_VO_COUNT | int %}
+{% for n in range(0,VO_COUNT) %}
+    {% set vo = '$' + '{RUCIO_FTS_VO_' + n|string + '}' %}
+    {% set voms = '$' + '{RUCIO_FTS_VOMS_' + n|string + '}' %}
 
-# We have to copy the certificates because we cannot change permissions on them as mounted secrets and voms-proxy is particular about permissions
-mkdir /tmp/{{ voms }}/
-cp /opt/rucio/certs/{{ voms }}/{{ RUCIO_LONG_PROXY }} /tmp/{{ voms }}/long.proxy
-chmod 400 /tmp/{{ voms }}/long.proxy
+    printf "=================== {{ vo }} Renewal =========================\n\n"
 
-# Generate a proxy with the voms extension if requested
-voms-proxy-init2 -valid 24:00 -cert /tmp/{{ voms }}/long.proxy -key /tmp/{{ voms }}/long.proxy -out /tmp/x509up_{{ voms }} -voms {{ voms }} -rfc -timeout 5
+    # We have to copy the certificates because we cannot change permissions on them as mounted secrets and voms-proxy is particular about permissions
+    mkdir /tmp/{{ vo }}/
+    cp /opt/rucio/certs/{{ vo }}/{{ RUCIO_LONG_PROXY }} /tmp/{{ vo }}/long.proxy
+    chmod 400 /tmp/{{ vo }}/long.proxy
 
-# Delegate the proxy to the requested servers
-{% if RUCIO_FTS_SERVERS is defined %}
-{% set ftses = RUCIO_FTS_SERVERS.split(',') %}
-{% for fts in ftses %}
-fts-rest-delegate --hours=24 --force --key=/tmp/x509up_{{ voms }} --cert=/tmp/x509up_{{ voms }} -s {{ fts }}
+    # Generate a proxy with the voms extension if requested and add them to string for use in kubectl
+    voms-proxy-init2 -valid 24:00 -cert /tmp/{{ vo }}/long.proxy -key /tmp/{{ vo }}/long.proxy -out /tmp/x509up_{{ vo }} -voms {{ voms }} -rfc -timeout 5
+
+    {% set ns.secrets = ns.secrets + ' --from-file=/tmp/x509up_' +  vo + ' ' %}
+
+    # Delegate the proxy to the requested servers
+    {% if RUCIO_FTS_SERVERS is defined %}
+      {% set ftses = RUCIO_FTS_SERVERS.split(',') %}
+      {% for fts in ftses %}
+        fts-rest-delegate --hours=24 --force --key=/tmp/x509up_{{ vo }} --cert=/tmp/x509up_{{ vo }} -s {{ fts }}
+      {% endfor %}
+    {% endif %}
+
+  printf "\n=============== {{ vo }} Renewal Complete ====================\n\n"
+  
+
+
 {% endfor %}
-{% endif %}
+
 
 # Create the corresponding kubernetes secrets if asked
 {% if RUCIO_FTS_SECRETS is defined %}
-{% set secrets = RUCIO_FTS_SECRETS.split(',') %}
-{% for secret in secrets %}
-kubectl create secret generic  {{ secret }}-{{ voms }} --from-file=/tmp/x509up_{{ voms }} --dry-run=client -o yaml | kubectl apply --validate=false  -f  -
-{% endfor %}
-{% endif %}
-
-printf "\n=============== {{ voms }} Renewal Complete ====================\n\n"
-
-{% endfor %}
+  {% set fts_secrets = RUCIO_FTS_SECRETS %}
+  kubectl create secret generic  {{ fts_secrets }} {{ ns.secrets }} --dry-run=client -o yaml | kubectl apply --validate=false  -f  -
 {% endif %}


### PR DESCRIPTION
The config required is now only the list of VOs and VOMS roles defined in the fts-cron section
The script will then generate proxy to the number of defined VOs, delegate to FTS for each, and collect into a single secret that is then defined in the daemons config for conveyor as prepared by Radu