### PR TITLE
Install cron into the probes container, allow switching between cron …

### DIFF
--- a/probes/DeterministicDelay
+++ b/probes/DeterministicDelay
@@ -1,0 +1,56 @@
+#! /usr/bin/env python3
+
+"""
+Delays running a command by a consistent amount of time based on the hash of the command string.
+This may be useful in spreading the load out from frequently running cronjobs.
+"""
+
+import argparse
+import hashlib
+import subprocess
+import time
+
+parser = argparse.ArgumentParser(
+    prog='DeterministicDelay',
+    description=('Delays running a command by a consistent amount of time. '
+                 'This may be useful in spreading the load out from frequently running cronjobs.'),
+    epilog=None)
+
+parser.add_argument('-d', required=False, dest='delay',
+                    help=("The maximum amount of time to delay. "
+                          "60 seconds is the default, suffix "
+                          "with s (the default), m, h, or d for seconds, minutes, hours, or days.")
+                    )
+parser.add_argument('commands', nargs='*', help="The commands to run")
+args = parser.parse_args()
+
+command_hash = hashlib.sha256(bytes(str(args.commands), 'utf-8'))
+checksum = int(command_hash.hexdigest(), 16)
+
+if not args.delay:
+    max_delay = 60
+else:
+    if args.delay[-1] in ['s', 'm', 'h', 'd']:
+        delay_value, delay_unit = args.delay[:-1], args.delay[-1]
+        if delay_unit == 'm':
+            max_delay = int(delay_value) * 60
+        elif delay_unit == 'h':
+            max_delay = int(delay_value) * 60 * 60
+        elif delay_unit == 'd':
+            max_delay = int(delay_value) * 24 * 60 * 60
+        else:
+            max_delay = int(delay_value)
+    else:
+        max_delay = int(args.delay)
+
+delay = checksum % max_delay
+
+print(f"Sleeping {delay}s")
+time.sleep(delay)
+
+executed = subprocess.run(args.commands, capture_output=True)
+
+print("STDOUT")
+print(executed.stdout)
+print("STDERR")
+print(executed.stderr)

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -15,6 +15,7 @@ ADD oic.rpm /tmp
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
     dnf install -y \
+        cronie-noanacron \
         git \
         gcc \
         libnsl \
@@ -43,7 +44,7 @@ WORKDIR /
 RUN git clone https://github.com/rucio/probes.git
 
 ADD rucio.config.default.cfg /tmp/
-
+ADD DeterministicDelay /
 ADD run-probes.sh /
 
 ENTRYPOINT ["/run-probes.sh"]

--- a/probes/run-probes.sh
+++ b/probes/run-probes.sh
@@ -18,14 +18,20 @@ if [ ! -z "$RUCIO_PRINT_CFG" ]; then
     echo ""
 fi
 
-cp /etc/jobber-config/dot-jobber.yaml /root/.jobber
+if [ ! -z "$RUCIO_USING_CRON" ]; then
+  echo "Setting up and starting cron"
+  cp /etc/cron.rucio/probes-crontab /etc/cron.d/
+  crond -n -s
+else
+  cp /etc/jobber-config/dot-jobber.yaml /root/.jobber
 
-echo "Starting Jobber"
-/usr/local/libexec/jobbermaster &
+  echo "Not using cron. Starting Jobber"
+  /usr/local/libexec/jobbermaster &
 
-sleep 5
+  sleep 5
 
-echo
-echo "============= Jobber log file ============="
+  echo
+  echo "============= Jobber log file ============="
 
-tail -f /var/log/jobber-runs
+  tail -f /var/log/jobber-runs
+fi


### PR DESCRIPTION
…and jobber, and add a script to deterministically delay running a command

This is accompanied by changes (no PR yet) in the helm chart. I'd propose this for Rucio 39, I think.

@dchristidis I know you've said you don't rely on this container (and no one but CMS does) but it'd still be good to have a quick look from someone.