### PR TITLE
Add AlmaLinux 10 based server image Dockerfile

### DIFF
--- a/server/j2.py
+++ b/server/j2.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def main(args):
+    j2_env = Environment()
+    with open(args[0], 'r') as fhandle:
+        j2_tpl = fhandle.read()
+    j2_tpl = j2_env.from_string(j2_tpl)
+
+    print(j2_tpl.render(**os.environ))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+


### PR DESCRIPTION
Initial idea for how an AlmaLinux 10 based image could look like. The main issue I see right now is the missing `gridsite` package (Apache HTTP module set) in EL10.

@maany @bari12 @dchristidis do you see any replacement for this?

I mark this is a draft to add changes for the client container image after the weekend.