### PR TITLE
Enable WSGI stdout logging in dev Apache configuration

### DIFF
--- a/dev/rucio.conf
+++ b/dev/rucio.conf
@@ -1,9 +1,17 @@
 SSLSessionCache  shmcb:/var/log/httpd/ssl_scache(512000)
 
 Listen 443
+# In mod_wsgi *daemon* mode, the daemon workers write stderr to the *main* Apache
+# error log (not the vhost error log). By pointing the main ErrorLog to the same file
+# as the vhost below, we unify all REST outputs
+ErrorLog /var/log/rucio/httpd_error_log
 
 WSGIRestrictEmbedded On
 WSGIDaemonProcess rucio processes=4 threads=4
+# Allow the app to access and write to sys.stdout (e.g., via print statements or direct writes).
+# Keep in mind that any output sent to sys.stdout gets redirected to sys.stderr instead.
+# This setting is mainly for debugging (not for production systems).
+WSGIRestrictStdout Off
 WSGIApplicationGroup rucio
 
 <VirtualHost *:443>
@@ -27,7 +35,8 @@ WSGIApplicationGroup rucio
  </Location>
  
  LogLevel debug authz_core:info ssl:info socache_shmcb:info
-
+ # Point the vhost error logging to the same file as the main ErrorLog (at the top).
+ # This way we keep all outputs at one place.
  ErrorLog /var/log/rucio/httpd_error_log
  TransferLog /var/log/rucio/httpd_access_log
 


### PR DESCRIPTION
Fixes #449

The patch adds a global `ErrorLog` directive so the main server writes to `/var/log/rucio/httpd_error_log`. Also, disabling `WSGIRestrictStdout` allows daemon worker stdout/stderr to flow into the Apache error log. These are the changes required from the container side along with others from the rucio side that will be pushed as the next step.