### PR TITLE
webui: apply dowgrade setuptools workaround

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -22,6 +22,10 @@ RUN dnf -y update && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
+    # Downgrade setuptools to avoid compatibility issues
+# TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
+RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm
+
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade setuptools
 RUN python3 -m pip install --no-cache-dir j2cli


### PR DESCRIPTION
Introduce a workaround in the `webui/Dockerfile` to address compatibility issues with the `setuptools` package. Specifically, downgrade `setuptools` to a known compatible version to avoid problems until an #458 issue is resolved.

Dependency management:

* Added a step to install an older version of `python3-setuptools` (`53.0.0-13.el9_6.1`) to avoid compatibility issues, with a TODO to remove this once the upstream issue (https://github.com/rucio/containers/issues/458) is fixed.The attempt to release the WebUI failed with the following setuptools error

Failing workflow: https://github.com/rucio/containers/actions/runs/20276621589/job/58227085062#step:9:980 

