### PR TITLE
Make NoDecode the default setting for AllowEncodedSlashes #469

### DIFF
--- a/server/rucio.conf.j2
+++ b/server/rucio.conf.j2
@@ -82,11 +82,7 @@ CacheRoot /tmp
  ErrorLog /dev/stderr
 {% endif %}
 
-{% if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE|default('False') == 'True' %}
  AllowEncodedSlashes NoDecode
-{% elif RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
- AllowEncodedSlashes on
-{% endif %}
 
  RewriteEngine on
  RewriteCond %{REQUEST_METHOD} ^(TRACE|TRACK)

--- a/ui/rucio.conf.j2
+++ b/ui/rucio.conf.j2
@@ -126,11 +126,7 @@ CacheRoot /tmp
 {% endif %}
  SSLVerifyClient optional
  SSLVerifyDepth 10
-{% if RUCIO_HTTPD_ENCODED_SLASHES_NO_DECODE|default('False') == 'True' %}
  AllowEncodedSlashes NoDecode
-{% elif RUCIO_HTTPD_ENCODED_SLASHES|default('False') == 'True' %}
- AllowEncodedSlashes on
-{% endif %}
 {% if RUCIO_HTTPD_LEGACY_DN|default('False') == 'True' %}
  SSLOptions +StdEnvVars +LegacyDNStringFormat
 {% else %}


### PR DESCRIPTION
Having this as the default setting will allow us to simplify the parsing of scopes and names on the server and close https://github.com/rucio/rucio/issues/7519 .