### PR TITLE
docs: correct support channels link text

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -94,4 +94,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).

--- a/daemons/README.md
+++ b/daemons/README.md
@@ -190,4 +190,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).

--- a/fs/README.md
+++ b/fs/README.md
@@ -103,4 +103,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).

--- a/init/README.md
+++ b/init/README.md
@@ -46,4 +46,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).

--- a/server/README.md
+++ b/server/README.md
@@ -183,4 +183,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).

--- a/ui/README.md
+++ b/ui/README.md
@@ -183,4 +183,4 @@ The available environment variables are:
 ## Getting Support
 
 If you are looking for support, please contact our mailing list rucio-users@googlegroups.com
-or join us on our [slack support](<https://rucio.slack.com/messages/#support>) channel.
+or reach out via our [support channels](<https://rucio.github.io/documentation/contact_us>).


### PR DESCRIPTION
This PR fixes incorrect references to a Slack support channel and replaces them with a link to the current support channels documentation (https://rucio.github.io/documentation/contact_us/).

Fixes #373 