### PR TITLE
Allow `--ignore-installed` flag for setuptools and wheel upgrades in dev container.

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir -p \
       tools
 
 RUN python3 -m pip install --no-cache --upgrade pip && \
-    python3 -m pip install --no-cache --upgrade setuptools wheel && \
+    python3 -m pip install --no-cache --upgrade --ignore-installed setuptools wheel && \
     python3 -m pip install --no-cache --upgrade -r /tmp/rucio/requirements/requirements.dev.txt ; \
     ln -s $RUCIOHOME/lib/rucio /usr/local/lib/python3.9/site-packages/rucio
 


### PR DESCRIPTION
Handles #478

To get things unstuck, I am pushing it now to get things going. Nevertheless, there is the #475 under review that uses `venv`, addressing the problem in a better way. But I think this might take some time.