### PR TITLE
fix(webui): replace j2cli with jinja2-cli to fix Apache config rendering

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -22,13 +22,8 @@ RUN dnf -y update && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-    # Downgrade setuptools to avoid compatibility issues
-# TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
-RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm
-
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir --upgrade setuptools
-RUN python3 -m pip install --no-cache-dir j2cli
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN python3 -m pip install --no-cache-dir jinja2-cli
 
 WORKDIR /opt/rucio/webui
 

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -42,12 +42,12 @@ cat /opt/rucio/webui/.env
 echo ""
 
 log "Building Apache configuration files."
-j2 /tmp/httpd.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf/httpd.conf
+env | jinja2 /tmp/httpd.conf.j2 -f env | sed '/^\s*$/d' > /etc/httpd/conf/httpd.conf
 echo "=================== /etc/httpd/conf/httpd.conf ========================"
 cat /etc/httpd/conf/httpd.conf
 echo ""
 
-j2 /tmp/rucio.conf.j2 | sed '/^\s*$/d' > /etc/httpd/conf.d/rucio.conf
+env | jinja2 /tmp/rucio.conf.j2 -f env | sed '/^\s*$/d' > /etc/httpd/conf.d/rucio.conf
 echo "=================== /etc/httpd/conf/conf.d/rucio.conf ========================"
 cat /etc/httpd/conf.d/rucio.conf
 echo ""


### PR DESCRIPTION
- Replace unmaintained `j2cli` with actively maintained [`jinja2-cli`](https://pypi.org/project/jinja2-cli/) (v1.0.0) in the webui container
- Remove the `setuptools` upgrade from the Dockerfile (no longer needed; also avoids the RPM RECORD file conflict from #478)
- Update entrypoint to use `env | jinja2 ... -f env` syntax for environment variable passthrough


`j2cli` depends on `pkg_resources` which breaks with setuptools >= 74. The webui container ships setuptools 82.0.0, causing `j2` to fail silently — producing empty `httpd.conf` and `rucio.conf`. Apache then exits with `AH00534: No MPM loaded` and the pod enters CrashLoopBackOff.

Closes #485