### PR TITLE
Webui Dockerfile: multi-stage build, upgrade to AlmaLinux 10 + Node.js 24

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -8,32 +8,20 @@
 # - Mayank Sharma, <mayank.sharma@cern.ch>, 2022
 # - Eraldo Junior <ejunior@cbpf.br>, 2023
 
-FROM almalinux:9
+# ---------- Stage 1: builder (clone repo & install node deps) ----------
+FROM almalinux:10 AS builder
 
 ARG TAG
 
-LABEL stage=production
 ENV NODE_ENV=production
 
 RUN dnf -y update && \
-    dnf -y module reset nodejs && \
-    dnf -y module enable nodejs:20 && \
-    dnf -y module install nodejs:20/common && \
-    dnf -y install httpd mod_ssl python39 python-pip git procps patch patchutils && \
-    dnf -y install wget && \
+    dnf -y install git nodejs24 nodejs24-npm && \
     dnf clean all && \
-    rm -rf /var/cache/dnf
-
-    # Downgrade setuptools to avoid compatibility issues
-# TODO: remove once https://github.com/rucio/containers/issues/458 is resolved
-RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/python3-setuptools-53.0.0-13.el9_6.1.noarch.rpm
-
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir --upgrade setuptools
-
-COPY j2.py /usr/local/bin/
-RUN python3 -m pip install --no-cache-dir jinja2 && \
-    ln -s j2.py /usr/local/bin/j2
+    rm -rf /var/cache/dnf && \
+    ln -s /usr/bin/node-24 /usr/local/bin/node && \
+    ln -s /usr/bin/npm-24 /usr/local/bin/npm && \
+    ln -s /usr/bin/npx-24 /usr/local/bin/npx
 
 WORKDIR /opt/rucio/webui
 
@@ -44,6 +32,37 @@ RUN git clone --depth 1 -b ${TAG} -- https://github.com/rucio/webui.git ${RUCIO_
 
 RUN npm i -g pm2
 RUN npm install --omit=dev
+
+# Pre-build env-generator so it's ready at runtime (needs dev deps for tsc)
+WORKDIR /opt/rucio/webui/tools/env-generator
+RUN npm install --include=dev && npx tsc --skipLibCheck && cp -rf src/templates dist/
+WORKDIR /opt/rucio/webui
+
+# ---------- Stage 2: runtime ----------
+FROM almalinux:10
+
+LABEL stage=production
+ENV NODE_ENV=production
+
+RUN dnf -y update && \
+    dnf -y install nodejs24 nodejs24-npm httpd mod_ssl python3 python3-jinja2 procps patch patchutils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf && \
+    ln -s /usr/bin/node-24 /usr/local/bin/node && \
+    ln -s /usr/bin/npm-24 /usr/local/bin/npm && \
+    ln -s /usr/bin/npx-24 /usr/local/bin/npx
+
+COPY j2.py /usr/local/bin/
+RUN ln -s j2.py /usr/local/bin/j2
+
+RUN npm i -g pm2
+
+WORKDIR /opt/rucio/webui
+
+ENV RUCIO_WEBUI_PATH=/opt/rucio/webui
+
+COPY --from=builder /opt/rucio/webui/ /opt/rucio/webui/
+COPY --from=builder /opt/rucio/merge_rucio_configs.py /opt/rucio/merge_rucio_configs.py
 
 COPY docker-entrypoint.sh /
 COPY httpd.conf.j2 /tmp/

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -6,20 +6,17 @@ log() {
 
 generate_env_file() {
     cd tools/env-generator
-    npm install
-
-    log "Building env-generator (skipping lib checks to avoid parent node_modules conflicts)..."
-    npx tsc --skipLibCheck && cp -rf src/templates dist/
-    local build_exit=$?
-
-    if [ $build_exit -ne 0 ]; then
-        log "WARNING: Build had errors but checking if output exists..."
-    fi
 
     if [ ! -f ./dist/generate-env.js ]; then
-        log "ERROR: ./dist/generate-env.js was not created by build"
-        cd ../..
-        return 1
+        log "Pre-built env-generator not found, building now..."
+        npm install
+        npx tsc --skipLibCheck && cp -rf src/templates dist/
+
+        if [ ! -f ./dist/generate-env.js ]; then
+            log "ERROR: ./dist/generate-env.js was not created by build"
+            cd ../..
+            return 1
+        fi
     fi
 
     chmod +x ./dist/generate-env.js
@@ -59,7 +56,7 @@ if [ -z "${RUCIO_WEBUI_COMMUNITY_LOGO_URL}" ]; then
     log "Environment variable RUCIO_WEBUI_COMMUNITY_LOGO_URL is not set. The default experiment-icon will be used."
 else
     log "Downloading community logo from ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}"
-    wget -O /opt/rucio/webui/public/experiment-logo.png ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}
+    curl -fsSL -o /opt/rucio/webui/public/experiment-logo.png ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}
 fi
 
 if [ -d "/patch" ]


### PR DESCRIPTION
## Summary

- Split webui Dockerfile into a multi-stage build (builder + runtime), removing git and its transitive dependencies from the final image
- Upgrade to **AlmaLinux 10** + **Node.js 24 LTS**: ships Python 3.12 natively, eliminating the `python39` package and the setuptools downgrade workaround. Node.js 24 LTS has active support until October 2026, full maintenance until April 2028.
- Set `NODE_ENV=production` in both builder and runtime stages
- Remove j2/jinja2/pip/setuptools from builder stage (not needed there)
- Use `dnf install python3-jinja2` in runtime instead of pip, removing pip/setuptools entirely
- Use `npm install --omit=dev` to exclude dev dependencies from production, reducing image size and attack surface
- Pre-build the `tools/env-generator` TypeScript tool at image build time instead of compiling at every container startup. The entrypoint falls back to building on-the-fly only if the pre-built artifact is missing (e.g. when patches replace it).
- Remove unused `merge_rucio_configs.py` (not referenced by entrypoint or patching mechanism)
- Replace `wget` with `curl` in the entrypoint since wget is no longer installed

See https://github.com/rucio/containers/pull/492 for the equivalent changes backported to release-38 webui containers.

## Security scan results (Docker Scout)

Scanned with webui tag `39.3.5`:

| | Count |
|---|---|
| Packages | 1064 |
| CRITICAL | **0** |
| HIGH | **9** |
| MEDIUM | **1** |
| LOW | **2** |
| **Total** | **12** |

### Remaining vulnerabilities

**9 HIGH** — all vendored inside Next.js (`next/dist/compiled/`):

| Package | CVEs | Source |
|---|---|---|
| `tar@7.5.1` | 4 HIGH (CVE-2026-23950, CVE-2026-24842, CVE-2026-23745, CVE-2026-26960) | `next/dist/compiled/tar/` |
| `minimatch@10.0.3` | 1 HIGH (CVE-2026-26996) | `next/dist/compiled/` |
| `minimatch@9.0.5` | 1 HIGH (CVE-2026-26996) | `next/dist/compiled/` |
| `glob@10.4.5` | 1 HIGH (CVE-2025-64756) | `next/dist/compiled/glob/` |
| `glob@11.0.3` | 1 HIGH (CVE-2025-64756) | `next/dist/compiled/glob/` |
| `@isaacs/brace-expansion@5.0.0` | 1 HIGH (CVE-2026-25547) | `next/dist/compiled/` |

These are pre-compiled into the Next.js package itself and cannot be fixed via npm overrides. Requires a Next.js version upgrade in the webui repo.

**1 MEDIUM** — `tar@7.5.1` (CVE-2025-64118). Vendored inside Next.js.

**2 LOW** — `diff@8.0.2`, `pm2@6.0.14`. No fixes available for pm2.