### PR TITLE
feat(webui): multi-stage build, omit dev deps, pre-build env-generator

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -8,36 +8,59 @@
 # - Mayank Sharma, <mayank.sharma@cern.ch>, 2022
 # - Eraldo Junior <ejunior@cbpf.br>, 2023
 
-FROM almalinux:9
+# ---------- Stage 1: builder (clone repo & install node deps) ----------
+FROM almalinux:9 AS builder
 
 ARG TAG
 
-LABEL stage=production
+ENV NODE_ENV=production
+
 RUN dnf -y update && \
     dnf -y module reset nodejs && \
-    dnf -y module enable nodejs:20 && \
-    dnf -y module install nodejs:20/common && \
-    dnf -y install httpd mod_ssl python39 python-pip git procps patch patchutils && \
-    dnf -y install wget && \
+    dnf -y module enable nodejs:24 && \
+    dnf -y module install nodejs:24/common && \
+    dnf -y install git && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    python3 -m pip install --no-cache-dir --upgrade setuptools
-
-COPY j2.py /usr/local/bin/
-RUN python3 -m pip install --no-cache-dir jinja2 && \
-    ln -s j2.py /usr/local/bin/j2
 
 WORKDIR /opt/rucio/webui
 
 ENV RUCIO_WEBUI_PATH=/opt/rucio/webui
 
-RUN curl https://raw.githubusercontent.com/rucio/rucio/master/tools/merge_rucio_configs.py --output /opt/rucio/merge_rucio_configs.py
 RUN git clone --depth 1 -b ${TAG} -- https://github.com/rucio/webui.git ${RUCIO_WEBUI_PATH}
 
 RUN npm i -g pm2
-RUN npm install
+RUN npm install --omit=dev
+
+# Pre-build env-generator so it's ready at runtime (needs dev deps for tsc)
+WORKDIR /opt/rucio/webui/tools/env-generator
+RUN npm install --include=dev && npx tsc --skipLibCheck && cp -rf src/templates dist/
+WORKDIR /opt/rucio/webui
+
+# ---------- Stage 2: runtime ----------
+FROM almalinux:9
+
+LABEL stage=production
+ENV NODE_ENV=production
+
+RUN dnf -y update && \
+    dnf -y module reset nodejs && \
+    dnf -y module enable nodejs:24 && \
+    dnf -y module install nodejs:24/common && \
+    dnf -y install httpd mod_ssl python3 python3-jinja2 procps patch patchutils && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+COPY j2.py /usr/local/bin/
+RUN ln -s j2.py /usr/local/bin/j2
+
+RUN npm i -g pm2
+
+WORKDIR /opt/rucio/webui
+
+ENV RUCIO_WEBUI_PATH=/opt/rucio/webui
+
+COPY --from=builder /opt/rucio/webui/ /opt/rucio/webui/
 
 COPY docker-entrypoint.sh /
 COPY httpd.conf.j2 /tmp/

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -6,20 +6,17 @@ log() {
 
 generate_env_file() {
     cd tools/env-generator
-    npm install
-
-    log "Building env-generator (skipping lib checks to avoid parent node_modules conflicts)..."
-    npx tsc --skipLibCheck && cp -rf src/templates dist/
-    local build_exit=$?
-
-    if [ $build_exit -ne 0 ]; then
-        log "WARNING: Build had errors but checking if output exists..."
-    fi
 
     if [ ! -f ./dist/generate-env.js ]; then
-        log "ERROR: ./dist/generate-env.js was not created by build"
-        cd ../..
-        return 1
+        log "Pre-built env-generator not found, building now..."
+        npm install
+        npx tsc --skipLibCheck && cp -rf src/templates dist/
+
+        if [ ! -f ./dist/generate-env.js ]; then
+            log "ERROR: ./dist/generate-env.js was not created by build"
+            cd ../..
+            return 1
+        fi
     fi
 
     chmod +x ./dist/generate-env.js
@@ -59,7 +56,7 @@ if [ -z "${RUCIO_WEBUI_COMMUNITY_LOGO_URL}" ]; then
     log "Environment variable RUCIO_WEBUI_COMMUNITY_LOGO_URL is not set. The default experiment-icon will be used."
 else
     log "Downloading community logo from ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}"
-    wget -O /opt/rucio/webui/public/experiment-logo.png ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}
+    curl -fsSL -o /opt/rucio/webui/public/experiment-logo.png ${RUCIO_WEBUI_COMMUNITY_LOGO_URL}
 fi
 
 if [ -d "/patch" ]


### PR DESCRIPTION
## Summary

Backport of https://github.com/rucio/containers/pull/491 for release-38 webui containers.

- Split webui Dockerfile into a multi-stage build (builder + runtime), removing git and its transitive dependencies from the final image
- Use `npm install --omit=dev` to exclude dev dependencies from production, reducing image size and attack surface
- Pre-build the `tools/env-generator` TypeScript tool at image build time instead of compiling at every container startup
- Set `NODE_ENV=production` in both builder and runtime stages
- Upgrade Node.js from 20 (EOL April 2026) to **24 LTS** (supported until April 2028) via `nodejs:24` module stream
- Remove j2/jinja2/pip/setuptools from builder stage (not needed there)
- Use `dnf install python3-jinja2` in runtime instead of pip — no pip in the image at all
- Remove unused `merge_rucio_configs.py` (not referenced by entrypoint or patching mechanism)
- Replace `wget` with `curl` in the entrypoint since wget is no longer installed

## Security scan results (Docker Scout)

Scanned with webui tag `38.3.3`:

| | `release-38.3.0` (before) | After |
|---|---|---|
| Packages | 2375 | **1156** |
| CRITICAL | 3 | **0** |
| HIGH | 27 | **12** |
| MEDIUM | 60 | **29** |
| LOW | 8 | **3** |
| **Total** | **98** | **44** (-55%) |

### Remaining vulnerabilities

**12 HIGH** — Next.js vendored dependencies and RPM false positives:

| Package | CVEs | Source |
|---|---|---|
| `tar@7.5.1` | 4 HIGH | `next/dist/compiled/tar/` |
| `setuptools@53.0.0` | 3 HIGH | RPM `python3-setuptools` — **false positive**, see below |
| `@isaacs/brace-expansion@5.0.0` | 1 HIGH | npm dependency |
| `minimatch@10.0.3` | 1 HIGH | npm dependency |
| `minimatch@9.0.5` | 1 HIGH | `next/dist/compiled/` |
| `glob@11.0.3` | 1 HIGH | npm dependency |
| `glob@10.4.5` | 1 HIGH | `next/dist/compiled/glob/` |

These are pre-compiled into the Next.js package and cannot be fixed via npm overrides. Requires a Next.js version upgrade in the webui repo.

### False positives (RPM backported fixes)

**setuptools 53.0.0 (python3-setuptools-53.0.0-14.el9_5.1)**: Docker Scout flags CVE-2024-6345, CVE-2022-40897, and CVE-2025-47273 based on upstream version matching. However, AlmaLinux has backported the fixes:
- [ALSA-2023:0952](https://errata.almalinux.org/9/ALSA-2023-0952.html) (CVE-2022-40897)
- [ALSA-2024:5534](https://errata.almalinux.org/9/ALSA-2024-5534.html) (CVE-2024-6345)
- [ALSA-2025:10407](https://errata.almalinux.org/9/ALSA-2025-10407.html) (CVE-2025-47273)

**Jinja2 2.11.3 (python3-jinja2-2.11.3-8.el9_5)**: Docker Scout flags 4 MEDIUM CVEs based on upstream version matching. However, AlmaLinux has backported the fixes:
- [ALSA-2024:2348](https://errata.almalinux.org/9/ALSA-2024-2348.html) (CVE-2024-22195, CVE-2024-34064)
- [ALSA-2025:10407](https://errata.almalinux.org/9/ALSA-2025-10407.html) (CVE-2024-56201, CVE-2024-56326)

**20 of 29 MEDIUM — perl CVE-2023-47038** reported across 20 sub-packages. Docker Scout matches on the perl version (`5.32.1`) without checking the RPM release suffix (`-481.1.el9_6`) which contains the backported fix from [ALSA-2024:2228](https://errata.almalinux.org/9/ALSA-2024-2228.html). Trivy correctly reports 0 OS-level HIGH/CRITICAL CVEs on the same image.

Perl remains in the image as a runtime dependency of `patchutils` (provides `filterdiff` used in the entrypoint for patch application).

**Remaining MEDIUM/LOW** — `tar@7.5.1` (1M), `ajv@6.12.6`, `micromatch`, `js-yaml`, `cookie`, `diff`, `brace-expansion` — all in Next.js or npm dependencies, no fixes available within this container.