### PR TITLE
Pin `test-fts` to FTS prod EL9 versions and add service-versioned build workflow

### DIFF
--- a/.github/workflows/build-test-fts-by-service-version.yml
+++ b/.github/workflows/build-test-fts-by-service-version.yml
@@ -1,0 +1,71 @@
+name: build-test-fts-by-service-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      fts_server_version:
+        description: "fts-server version-release for el9 (see https://fts-repo.web.cern.ch/fts-repo/el9/x86_64/; e.g. 3.14.4-2.el9)"
+        required: true
+        default: "3.14.4-2.el9"
+      fts_rest_version:
+        description: "fts-rest-server version-release for el9 (e.g. 3.14.2-1.el9)"
+        required: true
+        default: "3.14.2-1.el9"
+      fts_monitoring_version:
+        description: "fts-monitoring version-release for el9 (e.g. 3.14.2-1.el9)"
+        required: true
+        default: "3.14.2-1.el9"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout containers repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Derive image tag
+        id: derive_tag
+        run: |
+          FTS_SERVER_VERSION="${{ github.event.inputs.fts_server_version }}"
+          # Drop the release/dist suffix for the tag (e.g. 3.14.4-2.el9 -> 3.14.4)
+          SERVER_VERSION_MAJOR="$(echo "${FTS_SERVER_VERSION}" | cut -d- -f1)"
+          IMAGE_TAG="rucio/test-fts:fts3-prod-${SERVER_VERSION_MAJOR}-el9"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if image already exists on Docker Hub
+        id: check_exists
+        run: |
+          IMAGE="${{ steps.derive_tag.outputs.image_tag }}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} already exists, skipping build."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} does not exist, will build."
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0
+
+      - name: Login to Docker Hub
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push test-fts for given FTS production bundle
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0
+        with:
+          context: ./test-fts
+          file: ./test-fts/Dockerfile
+          push: true
+          tags: ${{ steps.derive_tag.outputs.image_tag }}
+          build-args: |
+            FTS_SERVER_VERSION=${{ github.event.inputs.fts_server_version }}
+            FTS_REST_VERSION=${{ github.event.inputs.fts_rest_version }}
+            FTS_MONITORING_VERSION=${{ github.event.inputs.fts_monitoring_version }}
+

--- a/test-fts/Dockerfile
+++ b/test-fts/Dockerfile
@@ -23,6 +23,14 @@ ARG FTS_SERVER_VERSION=3.14.4-2.el9
 ARG FTS_REST_VERSION=3.14.2-1.el9
 ARG FTS_MONITORING_VERSION=3.14.2-1.el9
 
+# python3-django3 was removed from EPEL 9 after Django 3.2 EOL (April 2024),
+# but fts-monitoring still requires it. Install directly from Fedora Koji where
+# the build is archived.
+RUN dnf install -y \
+    https://kojipkgs.fedoraproject.org/packages/python-django3/3.2.25/1.el9/noarch/python3-django3-3.2.25-1.el9.noarch.rpm \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
 RUN dnf install -y \
     "fts-server-${FTS_SERVER_VERSION}" \
     "fts-mysql-${FTS_SERVER_VERSION}" \

--- a/test-fts/Dockerfile
+++ b/test-fts/Dockerfile
@@ -15,9 +15,23 @@ RUN curl -sSfL -o /etc/yum.repos.d/fts3.repo https://fts-repo.web.cern.ch/fts-re
   && curl -sSfL -o /etc/yum.repos.d/fts3-depend.repo https://fts-repo.web.cern.ch/fts-repo/fts3-depend.repo \
   && curl -sSfL -o /etc/yum.repos.d/dmc.repo https://dmc-repo.web.cern.ch/dmc-repo/dmc-el9.repo
 
-RUN  dnf install -y \
-    fts-server fts-mysql fts-rest-client fts-rest-server fts-monitoring \
-    fts-server-selinux fts-rest-server-selinux fts-monitoring-selinux \
+# Version arguments for the production FTS bundle on el9.
+# Defaults are taken from the latest production builds in
+# https://fts-repo.web.cern.ch/fts-repo/el9/x86_64/
+# and can be overridden at build time by the service-versioned workflow.
+ARG FTS_SERVER_VERSION=3.14.4-2.el9
+ARG FTS_REST_VERSION=3.14.2-1.el9
+ARG FTS_MONITORING_VERSION=3.14.2-1.el9
+
+RUN dnf install -y \
+    "fts-server-${FTS_SERVER_VERSION}" \
+    "fts-mysql-${FTS_SERVER_VERSION}" \
+    "fts-rest-client-${FTS_REST_VERSION}" \
+    "fts-rest-server-${FTS_REST_VERSION}" \
+    "fts-monitoring-${FTS_MONITORING_VERSION}" \
+    "fts-server-selinux-${FTS_SERVER_VERSION}" \
+    "fts-rest-server-selinux-${FTS_REST_VERSION}" \
+    "fts-monitoring-selinux-${FTS_MONITORING_VERSION}" \
     fts-msg \
     mysql \
     multitail \

--- a/test-fts/Dockerfile
+++ b/test-fts/Dockerfile
@@ -15,13 +15,16 @@ RUN curl -sSfL -o /etc/yum.repos.d/fts3.repo https://fts-repo.web.cern.ch/fts-re
   && curl -sSfL -o /etc/yum.repos.d/fts3-depend.repo https://fts-repo.web.cern.ch/fts-repo/fts3-depend.repo \
   && curl -sSfL -o /etc/yum.repos.d/dmc.repo https://dmc-repo.web.cern.ch/dmc-repo/dmc-el9.repo
 
-# Version arguments for the production FTS bundle on el9.
-# Defaults are taken from the latest production builds in
+# Optional version pinning for reproducible images.
+# When all FTS version args are provided, we install pinned RPM versions to
+# make the image deterministic. If not provided, we fall back to unpinned
+# latest installs, matching the historical behavior of docker-auto-build.yml workflow.
+# These arguments can be overridden at the build time by the service-versioned workflow.
+# Version arguments can be taken from production builds in
 # https://fts-repo.web.cern.ch/fts-repo/el9/x86_64/
-# and can be overridden at build time by the service-versioned workflow.
-ARG FTS_SERVER_VERSION=3.14.4-2.el9
-ARG FTS_REST_VERSION=3.14.2-1.el9
-ARG FTS_MONITORING_VERSION=3.14.2-1.el9
+ARG FTS_SERVER_VERSION=
+ARG FTS_REST_VERSION=
+ARG FTS_MONITORING_VERSION=
 
 # python3-django3 was removed from EPEL 9 after Django 3.2 EOL (April 2024),
 # but fts-monitoring still requires it. Install directly from Fedora Koji where
@@ -31,19 +34,35 @@ RUN dnf install -y \
   && dnf clean all \
   && rm -rf /var/cache/dnf
 
-RUN dnf install -y \
-    "fts-server-${FTS_SERVER_VERSION}" \
-    "fts-mysql-${FTS_SERVER_VERSION}" \
-    "fts-rest-client-${FTS_REST_VERSION}" \
-    "fts-rest-server-${FTS_REST_VERSION}" \
-    "fts-monitoring-${FTS_MONITORING_VERSION}" \
-    "fts-server-selinux-${FTS_SERVER_VERSION}" \
-    "fts-rest-server-selinux-${FTS_REST_VERSION}" \
-    "fts-monitoring-selinux-${FTS_MONITORING_VERSION}" \
-    fts-msg \
-    mysql \
-    multitail \
-    gfal2-plugin* \
+RUN if [ -n "${FTS_SERVER_VERSION}" ] && [ -n "${FTS_REST_VERSION}" ] && [ -n "${FTS_MONITORING_VERSION}" ]; then \
+      dnf install -y \
+        "fts-server-${FTS_SERVER_VERSION}" \
+        "fts-mysql-${FTS_SERVER_VERSION}" \
+        "fts-rest-client-${FTS_REST_VERSION}" \
+        "fts-rest-server-${FTS_REST_VERSION}" \
+        "fts-monitoring-${FTS_MONITORING_VERSION}" \
+        "fts-server-selinux-${FTS_SERVER_VERSION}" \
+        "fts-rest-server-selinux-${FTS_REST_VERSION}" \
+        "fts-monitoring-selinux-${FTS_MONITORING_VERSION}" \
+        fts-msg \
+        mysql \
+        multitail \
+        gfal2-plugin* ; \
+    else \
+      dnf install -y \
+        fts-server \
+        fts-mysql \
+        fts-rest-client \
+        fts-rest-server \
+        fts-monitoring \
+        fts-server-selinux \
+        fts-rest-server-selinux \
+        fts-monitoring-selinux \
+        fts-msg \
+        mysql \
+        multitail \
+        gfal2-plugin* ; \
+    fi \
   && dnf clean all \
   && rm -rf /var/cache/dnf
   


### PR DESCRIPTION
Fixes #494 

Right now the test-fts container installs latest versions from the FTS repos without pinning versions, and our tags are mostly tied to containers/Rucio releases or latest. That makes it hard to reproduce issues (especially for LTS branches) and it hides which FTS version is actually inside a given image.
This change does two things:

- In `test-fts/Dockerfile`, I now install FTS from the CERN EL9 repos using explicit version-release values, controlled by build args:
`FTS_SERVER_VERSION (default 3.14.4-2.el9)`
`FTS_REST_VERSION (default 3.14.2-1.el9)`
`FTS_MONITORING_VERSION (default 3.14.2-1.el9)`

The install step uses these args to pin `fts-server`, `fts-mysql`, `fts-rest-client`, `fts-rest-server`, `fts-monitoring` and their `selinux` packages. This means a given build is fully determined by those three RPM versions, and the defaults are aligned with the latest prod entries from the EL9 repo (https://fts-repo.web.cern.ch/fts-repo/el9/x86_64/).

- I added a new workflow `build-test-fts-by-service-version.yml` which is meant for LTS / controlled builds. It’s a workflow_dispatch job that takes the three FTS version-release strings as inputs, derives a tag of the form `rucio/test-fts:fts3-prod-<server-version>-el9`, checks Docker Hub to see if that tag already exists, and only builds/pushes the image if it doesn’t. The idea is that for each FTS prod bundle we want to support, we run this once, get a stable service-versioned tag, and then Rucio LTS branches can pin to that tag instead of latest.

We only ask for and pin the three core versions (`fts-server`, `fts-rest`, `fts-monitoring`) because that’s how FTS itself structures its release matrix: the production bundle is defined by those three versions, and the other RPMs like `fts-mysql`, `fts-server-selinux`, `fts-rest-client`, etc. track those core versions rather than introducing independent version axes. The official FTS version table (https://fts3-docs.web.cern.ch/fts3-docs/versions/) is essentially a matrix of these three components per channel (epel, prod, rc, devel). By taking `fts_server_version`, `fts_rest_version` and `fts_monitoring_version` as inputs and deriving all the other FTS packages from them, we match how the prod bundle is defined while avoiding unnecessary complexity and the risk of mixing incompatible RPM versions.

I intentionally did not touch the existing `docker-auto-build.yml `so the current release flow (tags based on containers repo releases) keeps working as before. The new workflow and pinned Dockerfile are an extra lane we can use when we care about strict FTS versioning and reproducibility as we do it for the `LTS` releases.