### PR TITLE
Pin `test-xrootd-noauth` to xrootd builds and add service versioned workflow

### DIFF
--- a/.github/workflows/build-test-xrootd-noauth-by-service-version.yml
+++ b/.github/workflows/build-test-xrootd-noauth-by-service-version.yml
@@ -1,0 +1,64 @@
+name: build-test-xrootd-noauth-by-service-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      xrootd_version:
+        description: "xrootd version-release for el9 (e.g. 5.9.1-1.el9)"
+        required: true
+        default: "5.9.1-1.el9"
+        # This value is passed through to the Docker build as `XROOTD_VERSION`.
+        # If you leave the input as-is when triggering the workflow, the Dockerfile
+        # will pin `xrootd*` packages to this exact RPM version-release.
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout containers repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Derive image tag
+        id: derive_tag
+        run: |
+          XROOTD_VERSION="${{ github.event.inputs.xrootd_version }}"
+          # Drop the release/dist suffix for the tag (e.g. 5.9.1-1.el9 -> 5.9.1)
+          VERSION_MAJOR="$(echo "${XROOTD_VERSION}" | cut -d- -f1)"
+          IMAGE_TAG="rucio/test-xrootd-noauth:xrootd-noauth-${VERSION_MAJOR}-el9"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if image already exists on Docker Hub
+        id: check_exists
+        run: |
+          IMAGE="${{ steps.derive_tag.outputs.image_tag }}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} already exists, skipping build."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image ${IMAGE} does not exist, will build."
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0
+
+      - name: Login to Docker Hub
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push test-xrootd-noauth for given XRootD production bundle
+        if: steps.check_exists.outputs.exists == 'false'
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0
+        with:
+          context: ./test-xrootd-noauth
+          file: ./test-xrootd-noauth/Dockerfile
+          push: true
+          tags: ${{ steps.derive_tag.outputs.image_tag }}
+          build-args: |
+            XROOTD_VERSION=${{ github.event.inputs.xrootd_version }}
+

--- a/test-xrootd-noauth/Dockerfile
+++ b/test-xrootd-noauth/Dockerfile
@@ -1,9 +1,22 @@
 FROM almalinux:9
 
+# Optional version pinning for reproducible images.
+# When `XROOTD_VERSION` is provided (e.g. `5.9.1-1.el9`), we install
+# `xrootd*` packages with explicit RPM versions to make the image
+# deterministic. If not provided, we fall back to unpinned installs,
+# matching the historical behavior.
+ARG XROOTD_VERSION=
+
 RUN dnf install -y epel-release.noarch && \
     dnf update -y && \
     dnf upgrade -y && \
-    dnf install -y xrootd xrootd-client && \
+    if [ -n "${XROOTD_VERSION}" ]; then \
+      dnf install -y \
+        "xrootd-${XROOTD_VERSION}" \
+        "xrootd-client-${XROOTD_VERSION}" ; \
+    else \
+      dnf install -y xrootd xrootd-client ; \
+    fi && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
Fixes #498 

`test-xrootd-noauth` can now be built in a reproducible way for lts releases by pinning XRootD RPMs via `XROOTD_VERSION`, while still keeping the old unpinned behavior when no version is provided. Also adds a manual GitHub Action to build and push `xrootd-noauth-<version>-el9` tags, with a default version input and a skip-if-tag-exists check.