### PR TITLE
Add arch suffix (eg. `x86_64`) to test-xrootd version

### DIFF
--- a/.github/workflows/build-test-xrootd-by-service-version.yml
+++ b/.github/workflows/build-test-xrootd-by-service-version.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       xrootd_version:
-        description: "xrootd version-release for el9 (e.g. 5.9.1-1.el9)"
+        description: "xrootd version-release for el9 (e.g. 5.9.2-1.el9.x86_64)"
         required: true
-        default: "5.9.1-1.el9"
+        default: "5.9.2-1.el9.x86_64"
         # This value is passed through to the Docker build as `XROOTD_VERSION`.
         # If you leave the input as-is when triggering the workflow, the Dockerfile
         # will pin `xrootd*` packages to this exact RPM version-release.
@@ -23,7 +23,7 @@ jobs:
         id: derive_tag
         run: |
           XROOTD_VERSION="${{ github.event.inputs.xrootd_version }}"
-          # Drop the release/dist suffix for the tag (e.g. 5.9.1-1.el9 -> 5.9.1)
+          # Drop the release/dist suffix for the tag (e.g. 5.9.2-1.el9.x86_64 -> 5.9.2)
           VERSION_MAJOR="$(echo "${XROOTD_VERSION}" | cut -d- -f1)"
           IMAGE_TAG="rucio/test-xrootd:xrootd-${VERSION_MAJOR}-el9"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test-xrootd-noauth-by-service-version.yml
+++ b/.github/workflows/build-test-xrootd-noauth-by-service-version.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       xrootd_version:
-        description: "xrootd version-release for el9 (e.g. 5.9.1-1.el9)"
+        description: "xrootd version-release for el9 (e.g. 5.9.2-1.el9.x86_64)"
         required: true
-        default: "5.9.1-1.el9"
+        default: "5.9.2-1.el9.x86_64"
         # This value is passed through to the Docker build as `XROOTD_VERSION`.
         # If you leave the input as-is when triggering the workflow, the Dockerfile
         # will pin `xrootd*` packages to this exact RPM version-release.
@@ -23,7 +23,7 @@ jobs:
         id: derive_tag
         run: |
           XROOTD_VERSION="${{ github.event.inputs.xrootd_version }}"
-          # Drop the release/dist suffix for the tag (e.g. 5.9.1-1.el9 -> 5.9.1)
+          # Drop the release/dist suffix for the tag (e.g. 5.9.2-1.el9.x86_64 -> 5.9.2)
           VERSION_MAJOR="$(echo "${XROOTD_VERSION}" | cut -d- -f1)"
           IMAGE_TAG="rucio/test-xrootd-noauth:xrootd-noauth-${VERSION_MAJOR}-el9"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes test failures related to not finding available versions in `test-xrootd` and `test-xrootd-noauth`: https://github.com/rucio/containers/actions/runs/24503325565/job/71615441810 and https://github.com/rucio/containers/actions/runs/24500789483/job/71606735835

Successful run: https://github.com/rucio/containers/actions/runs/24511012492/job/71641876931

Related: #493 