### PR TITLE
Dependencies: Install Oracle Instant Client with dnf

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -7,8 +7,10 @@
 FROM almalinux:9
 
 ARG TAG
+ARG ORACLE_INSTANTCLIENT_VERSION=23.26.2.0.0
 
 WORKDIR /tmp
+COPY oracle-instantclient.repo /etc/yum.repos.d/
 
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
@@ -21,6 +23,7 @@ RUN dnf install -y epel-release.noarch && \
         gfal2-plugin-xrootd \
         libnsl \
         libaio \
+        oracle-instantclient-basiclite-${ORACLE_INSTANTCLIENT_VERSION} \
         patch \
         python-gfal2 \
         procps-ng \

--- a/daemons/oracle-instantclient.repo
+++ b/daemons/oracle-instantclient.repo
@@ -1,0 +1,6 @@
+[oracle-instantclient]
+name=Oracle Instant Client 23 for Oracle Linux 9
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient23/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -1,8 +1,10 @@
 FROM almalinux:9
 
 ARG TAG
+ARG ORACLE_INSTANTCLIENT_VERSION=23.26.2.0.0
 
 WORKDIR /tmp
+COPY oracle-instantclient.repo /etc/yum.repos.d/
 
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
@@ -12,6 +14,7 @@ RUN dnf install -y epel-release.noarch && \
         libaio \
         openssl-devel \
         mod_ssl \
+        oracle-instantclient-basiclite-${ORACLE_INSTANTCLIENT_VERSION} \
         procps-ng \
         python-devel \
         python3-m2crypto \

--- a/init/oracle-instantclient.repo
+++ b/init/oracle-instantclient.repo
@@ -1,0 +1,6 @@
+[oracle-instantclient]
+name=Oracle Instant Client 23 for Oracle Linux 9
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient23/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9

--- a/probes/Dockerfile
+++ b/probes/Dockerfile
@@ -8,9 +8,10 @@
 # - Eric Vaandering, <ewv@fnal.gov>, 2020
 
 FROM almalinux:9
+ARG ORACLE_INSTANTCLIENT_VERSION=23.26.2.0.0
 
 WORKDIR /tmp
-ADD oic.rpm /tmp
+COPY oracle-instantclient.repo /etc/yum.repos.d/
 
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
@@ -20,6 +21,7 @@ RUN dnf install -y epel-release.noarch && \
         gcc \
         libnsl \
         libaio \
+        oracle-instantclient-basiclite-${ORACLE_INSTANTCLIENT_VERSION} \
         openssl-devel \
         procps-ng \
         python-devel \

--- a/probes/oracle-instantclient.repo
+++ b/probes/oracle-instantclient.repo
@@ -1,0 +1,6 @@
+[oracle-instantclient]
+name=Oracle Instant Client 23 for Oracle Linux 9
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient23/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,8 +7,10 @@
 FROM almalinux:9
 
 ARG TAG
+ARG ORACLE_INSTANTCLIENT_VERSION=23.26.2.0.0
 
 WORKDIR /tmp
+COPY oracle-instantclient.repo /etc/yum.repos.d/
 
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
@@ -16,6 +18,7 @@ RUN dnf install -y epel-release.noarch && \
         gridsite \
         libnsl \
         libaio \
+        oracle-instantclient-basiclite-${ORACLE_INSTANTCLIENT_VERSION} \
         patch \
         procps-ng \
         python-pip \

--- a/server/oracle-instantclient.repo
+++ b/server/oracle-instantclient.repo
@@ -1,0 +1,6 @@
+[oracle-instantclient]
+name=Oracle Instant Client 23 for Oracle Linux 9
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient23/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -10,8 +10,10 @@
 FROM almalinux:9
 
 ARG TAG
+ARG ORACLE_INSTANTCLIENT_VERSION=23.26.2.0.0
 
 WORKDIR /tmp
+COPY oracle-instantclient.repo /etc/yum.repos.d/
 
 RUN dnf install -y epel-release.noarch && \
     dnf upgrade -y && \
@@ -22,6 +24,7 @@ RUN dnf install -y epel-release.noarch && \
         libaio \
         openssl-devel \
         mod_ssl \
+        oracle-instantclient-basiclite-${ORACLE_INSTANTCLIENT_VERSION} \
         procps-ng \
         python3-mod_wsgi \
         python3-m2crypto \

--- a/ui/oracle-instantclient.repo
+++ b/ui/oracle-instantclient.repo
@@ -1,0 +1,6 @@
+[oracle-instantclient]
+name=Oracle Instant Client 23 for Oracle Linux 9
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient23/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol9


### PR DESCRIPTION
Fixes #522.

This installs Oracle Instant Client with `dnf` in the service and probe images so Oracle thick mode remains available.
It also removes the stale `probes/oic.rpm`.