### PR TITLE
fix: constrain setuptools<81 in pip build isolation for rucio 35 images

### DIFF
--- a/daemons/Dockerfile
+++ b/daemons/Dockerfile
@@ -58,7 +58,13 @@ RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/pyt
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade setuptools
-RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql,globus]==$TAG
+# Constrain setuptools inside pip's isolated build environments: cx_Oracle
+# (oracle extra of rucio<36) has no arm64 wheels and its setup.py imports
+# pkg_resources, which was removed in setuptools 81
+RUN echo "setuptools<81" > /tmp/pip-build-constraints.txt && \
+    PIP_CONSTRAINT=/tmp/pip-build-constraints.txt \
+    python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql,globus]==$TAG && \
+    rm -f /tmp/pip-build-constraints.txt
 
 COPY j2.py /usr/local/bin/
 RUN python3 -m pip install --no-cache-dir jinja2 && \

--- a/init/Dockerfile
+++ b/init/Dockerfile
@@ -29,7 +29,13 @@ RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/pyt
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools
-RUN python3 -m pip install --pre rucio[oracle,mysql,postgresql]==$TAG
+# Constrain setuptools inside pip's isolated build environments: cx_Oracle
+# (oracle extra of rucio<36) has no arm64 wheels and its setup.py imports
+# pkg_resources, which was removed in setuptools 81
+RUN echo "setuptools<81" > /tmp/pip-build-constraints.txt && \
+    PIP_CONSTRAINT=/tmp/pip-build-constraints.txt \
+    python3 -m pip install --pre rucio[oracle,mysql,postgresql]==$TAG && \
+    rm -f /tmp/pip-build-constraints.txt
 
 COPY j2.py /usr/local/bin/
 RUN python3 -m pip install --no-cache-dir jinja2 && \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -34,7 +34,13 @@ RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/pyt
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir --upgrade setuptools
-RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
+# Constrain setuptools inside pip's isolated build environments: cx_Oracle
+# (oracle extra of rucio<36) has no arm64 wheels and its setup.py imports
+# pkg_resources, which was removed in setuptools 81
+RUN echo "setuptools<81" > /tmp/pip-build-constraints.txt && \
+    PIP_CONSTRAINT=/tmp/pip-build-constraints.txt \
+    python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG && \
+    rm -f /tmp/pip-build-constraints.txt
 
 COPY j2.py /usr/local/bin/
 RUN python3 -m pip install --no-cache-dir jinja2 && \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -42,7 +42,13 @@ RUN dnf -y install https://vault.almalinux.org/9.6/BaseOS/x86_64/os/Packages/pyt
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip
 RUN python3 -m pip install --no-cache-dir --upgrade setuptools
-RUN python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG
+# Constrain setuptools inside pip's isolated build environments: cx_Oracle
+# (oracle extra of rucio<36) has no arm64 wheels and its setup.py imports
+# pkg_resources, which was removed in setuptools 81
+RUN echo "setuptools<81" > /tmp/pip-build-constraints.txt && \
+    PIP_CONSTRAINT=/tmp/pip-build-constraints.txt \
+    python3 -m pip install --no-cache-dir --pre rucio[oracle,mysql,postgresql]==$TAG && \
+    rm -f /tmp/pip-build-constraints.txt
 RUN python3 -m pip install --no-cache-dir --pre rucio_webui==$TAG
 
 COPY j2.py /usr/local/bin/


### PR DESCRIPTION
cx_Oracle 8.3.0 (oracle extra of rucio<36) publishes no arm64 wheels and is built from source on linux/arm64. Its setup.py imports pkg_resources, which setuptools 81 removed, so pip's isolated build environment fails with ModuleNotFoundError. This broke the server, daemons, ui and init builds of the 35.9.0 release. PIP_CONSTRAINT is honoured inside build isolation and is scoped to the rucio install.

Assisted-by: Claude