### PR TITLE
fix(webui): remove printing of .env file in entrypoint #527

### DIFF
--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -35,7 +35,6 @@ else
     log "/opt/rucio/webui/.env not found. Will generate one now."
     generate_env_file
 fi
-cat /opt/rucio/webui/.env
 echo ""
 
 log "Building Apache configuration files."


### PR DESCRIPTION
Stop printing the entire .env file in the webui entrypoint as it may leak secrets to monitoring environments by deleting the `cat .env` in the entrypoint.

This is the simplest fix to the problem instead of classifying config var's as secrets/open, which will be handled in https://github.com/rucio/webui/issues/753

Closes #527