### PR TITLE
feat(webui): download OIDC provider icons for local next/image serving

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -123,6 +123,7 @@ For each `OIDC Provider` specified in the `OIDC_PROVIDERS` variable, the additio
 | OIDC_PROVIDER_CERN_REFRESH_TOKEN_URL | RUCIO_WEBUI_OIDC_PROVIDER_CERN_REFRESH_TOKEN_URL | The refresh token endpoint                                            |         |         |
 | OIDC_PROVIDER_CERN_USERINFO_URL      | RUCIO_WEBUI_OIDC_PROVIDER_CERN_USERINFO_URL      | The URL to obtain user info from the OIDC Provider                    |         |         |
 | OIDC_PROVIDER_CERN_REDIRECT_URL      | RUCIO_WEBUI_OIDC_PROVIDER_CERN_REDIRECT_URL      | The redirection URL configured on the OIDC Provider                   |         |         |
+| OIDC_PROVIDER_CERN_ICON_URL          | RUCIO_WEBUI_OIDC_PROVIDER_CERN_ICON_URL          | URL to a raster icon (png/jpg) shown on the provider's login button. Downloaded at container start into `public/oidc-icons/CERN.png` and served via next/image; if unset or unreachable, a default icon is used. |         |         |
 
 ## Web Server Configuration
 

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -31,6 +31,36 @@ generate_env_file() {
     return $exit_code
 }
 
+download_oidc_icons() {
+    # OIDC provider icons are served locally so the WebUI can render them with
+    # next/image. The WebUI derives the served path from the provider name
+    # (public/oidc-icons/<NAME>.png, upper-cased) and only shows the icon when the
+    # file exists, so here we just place the file. A failed download is non-fatal:
+    # the WebUI falls back to its default icon.
+    if [ -z "${RUCIO_WEBUI_OIDC_PROVIDERS}" ]; then
+        return 0
+    fi
+
+    local icon_dir="/opt/rucio/webui/public/oidc-icons"
+    mkdir -p "${icon_dir}"
+
+    local name upper url_var url dest
+    for name in $(echo "${RUCIO_WEBUI_OIDC_PROVIDERS}" | tr ',' ' '); do
+        upper="$(echo "${name}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+        [ -z "${upper}" ] && continue
+        url_var="RUCIO_WEBUI_OIDC_PROVIDER_${upper}_ICON_URL"
+        url="${!url_var}"
+        [ -z "${url}" ] && continue
+
+        dest="${icon_dir}/${upper}.png"
+        log "Downloading OIDC icon for '${name}' from ${url}"
+        if ! wget -q -O "${dest}" "${url}"; then
+            log "WARNING: could not download OIDC icon for '${name}'; the WebUI will use the default icon"
+            rm -f "${dest}"
+        fi
+    done
+}
+
 echo "=================== /opt/rucio/webui/.env ==================="
 if [ -f /opt/rucio/webui/.env ]; then
     log "/opt/rucio/webui/.env already mounted."
@@ -54,6 +84,8 @@ echo ""
 
 log "removing httpd example ssl config"
 rm -rf /etc/httpd/conf.d/ssl.conf
+
+download_oidc_icons
 
 if [ -z "${RUCIO_WEBUI_COMMUNITY_LOGO_URL}" ]; then
     log "Environment variable RUCIO_WEBUI_COMMUNITY_LOGO_URL is not set. The default experiment-icon will be used."

--- a/webui/docker-entrypoint.sh
+++ b/webui/docker-entrypoint.sh
@@ -54,7 +54,10 @@ download_oidc_icons() {
 
         dest="${icon_dir}/${upper}.png"
         log "Downloading OIDC icon for '${name}' from ${url}"
-        if ! wget -q -O "${dest}" "${url}"; then
+        # This is a low-priority, best-effort download, so cap every phase with
+        # short timeouts and a single retry rather than relying on wget's
+        # 900s default that would stall container startup on a bad URL.
+        if ! wget -q --tries=2 --dns-timeout=5 --connect-timeout=5 --read-timeout=15 -O "${dest}" "${url}"; then
             log "WARNING: could not download OIDC icon for '${name}'; the WebUI will use the default icon"
             rm -f "${dest}"
         fi


### PR DESCRIPTION
Related to rucio/webui#805 and the WebUI-side change in rucio/webui#806.

## What

For every provider listed in `RUCIO_WEBUI_OIDC_PROVIDERS` that declares a
`RUCIO_WEBUI_OIDC_PROVIDER_<NAME>_ICON_URL`, we download the icon at container
start into `public/oidc-icons/<NAME>.png` (upper-cased name), mirroring the
existing community-logo handling. This lets the WebUI render provider icons with
`next/image` instead of a plain `<img>` pointing at an operator-supplied remote
host that cannot be allow-listed in `next.config`'s `images.remotePatterns`.

## How this differs from #529

This is an alternative to #529. Instead of rewriting the `*_ICON_URL` value in
the generated `.env` to the local path (and unsetting it on failure), we only
place the file. The WebUI gateway derives the served path from the provider name
and renders the icon only when the local file exists (see rucio/webui#806), so
the container does not need to touch `.env` or run before env generation, and a
failed download degrades to the default icon on its own.

Details:
- Reads the `RUCIO_WEBUI_`-prefixed environment variables directly, the same
  source the community logo uses.
- Uses `wget` (installed in the image; curl is build-time only) and removes the
  destination on failure so no 0-byte file is left behind.
- Non-fatal under `set -e`: a bad or unreachable icon URL logs a warning and
  container startup continues.

## Testing

Verified the download loop against sample env vars: a reachable icon lands at
`public/oidc-icons/<NAME>.png`, an unreachable one logs a warning and leaves no
file, and a provider without an icon URL is skipped, with the script exiting 0.